### PR TITLE
products: +tag 新命令 + search/count 过滤修复 + 清理

### DIFF
--- a/shortcuts/products/count.go
+++ b/shortcuts/products/count.go
@@ -11,13 +11,15 @@ var countShortcut = common.Shortcut{
 	Use:     "+count",
 	Short:   "Quickly count products",
 	Flags: []common.Flag{
-		{Name: "published", Type: common.FlagString, Description: "Filter by published status.", Completions: []string{"true", "false"}},
-		{Name: "vendor", Type: common.FlagString, Description: "Filter by vendor name."},
+		{Name: "published", Type: common.FlagString, Description: "Filter by published status: published, unpublished, any (true/false also accepted).", Completions: []string{"published", "unpublished", "any"}},
 	},
 	Plan: func(in common.PlanInput) (common.PlannedRequest, error) {
+		ps, err := normalizePublishedStatus(in.Flags.GetString("published"))
+		if err != nil {
+			return common.PlannedRequest{}, err
+		}
 		q := map[string]any{}
-		cmdutil.AddString(q, "published_status", in.Flags.GetString("published"))
-		cmdutil.AddString(q, "vendor", in.Flags.GetString("vendor"))
+		cmdutil.AddString(q, "published_status", ps)
 		return PlanCount(q), nil
 	},
 }

--- a/shortcuts/products/create.go
+++ b/shortcuts/products/create.go
@@ -59,7 +59,7 @@ var createShortcut = common.Shortcut{
 			"inventory_tracking":       stockTracked,
 			"images":                   []map[string]any{{"src": in.Flags.GetString("image")}},
 			"variants":                 []map[string]any{variant},
-			"unique_token":             generateUniqueToken(in.Tool),
+			"unique_token":             generateUniqueToken(),
 		}
 		if stockTracked {
 			product["inventory_policy"] = in.Flags.GetString("stock-policy")
@@ -76,7 +76,7 @@ var createShortcut = common.Shortcut{
 }
 
 // generateUniqueToken returns a random v4 UUID used as the idempotency token (the API requires a UUID).
-func generateUniqueToken(_ string) string {
+func generateUniqueToken() string {
 	var b [16]byte
 	_, _ = rand.Read(b[:])
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4

--- a/shortcuts/products/create.go
+++ b/shortcuts/products/create.go
@@ -22,7 +22,7 @@ var createShortcut = common.Shortcut{
 		{Name: "compare-price", Type: common.FlagString, Description: "Compare-at price."},
 		{Name: "sku", Type: common.FlagString, Description: "SKU."},
 		{Name: "stock", Type: common.FlagInt, Description: "Stock quantity (enables inventory tracking)."},
-		{Name: "stock-policy", Type: common.FlagString, Default: "deny", Description: "Inventory policy when stock=0.",
+		{Name: "stock-policy", Type: common.FlagString, Default: "deny", Description: "Inventory policy when stock=0: continue, deny, auto_unpublished.",
 			Completions: []string{"continue", "deny", "auto_unpublished"}},
 		{Name: "tags", Type: common.FlagStringSlice, Description: "Tags (comma-separated)."},
 		{Name: "published", Type: common.FlagBool, Description: "Publish on create (default: draft)."},

--- a/shortcuts/products/exec_test.go
+++ b/shortcuts/products/exec_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -26,6 +27,8 @@ func newProductExecInput(t *testing.T, flags map[string]string, values map[strin
 			cmd.Flags().Int(name, 0, "")
 		case "bool":
 			cmd.Flags().Bool(name, false, "")
+		case "stringslice":
+			cmd.Flags().StringSlice(name, nil, "")
 		}
 	}
 	var args []string
@@ -276,5 +279,144 @@ func TestSetPriceExecute_SKUMultiMatchRefuses(t *testing.T) {
 	}
 	if putCalled {
 		t.Error("must NOT update when the SKU matches multiple variants")
+	}
+}
+
+// ── tagShortcut.Execute ───────────────────────────────────────────────────────
+
+var tagExecFlags = map[string]string{
+	"id": "string", "add": "stringslice", "remove": "stringslice", "set": "stringslice",
+}
+
+func tagInputWithClient(t *testing.T, values map[string]string, baseURL string) common.ExecInput {
+	in := newProductExecInput(t, tagExecFlags, values, false)
+	in.Client = client.New(baseURL)
+	return in
+}
+
+// putTagsRecorder serves GET with the given current tags and records the tags
+// array sent by any PUT. The bool reports whether a PUT was received.
+func putTagsRecorder(t *testing.T, current []any, gotPut *bool, putTags *[]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPut {
+			*gotPut = true
+			var body struct {
+				Product struct {
+					Tags []any `json:"tags"`
+				} `json:"product"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			*putTags = body.Product.Tags
+			_ = json.NewEncoder(w).Encode(map[string]any{"product": map[string]any{"id": "p-1", "tags": body.Product.Tags}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"product": map[string]any{"id": "p-1", "tags": current}})
+	}))
+}
+
+func TestTagExecute_NoMutationFlagErrors(t *testing.T) {
+	in := newProductExecInput(t, tagExecFlags, map[string]string{"id": "p-1"}, false)
+	if _, err := tagShortcut.Execute(context.Background(), in); err == nil {
+		t.Error("expected error when none of --add/--remove/--set is given")
+	}
+}
+
+func TestTagExecute_SetWithAddErrors(t *testing.T) {
+	in := newProductExecInput(t, tagExecFlags, map[string]string{"id": "p-1", "set": "a", "add": "b"}, false)
+	if _, err := tagShortcut.Execute(context.Background(), in); err == nil {
+		t.Error("expected error when --set is combined with --add")
+	}
+}
+
+func TestTagExecute_DryRun_Set(t *testing.T) {
+	in := newProductExecInput(t, tagExecFlags, map[string]string{"id": "p-1", "set": "x,y,x"}, true)
+	r, err := tagShortcut.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Plans) != 1 || r.Plans[0].Method != "PUT" || !strings.HasSuffix(r.Plans[0].Path, "/products/p-1") {
+		t.Fatalf("set should be a single PUT; got %+v", r.Plans)
+	}
+	body, _ := r.Plans[0].Body.(map[string]any)
+	prod, _ := body["product"].(map[string]any)
+	if tags, _ := prod["tags"].([]string); !reflect.DeepEqual(tags, []string{"x", "y"}) {
+		t.Errorf("set body tags should be deduped [x y]; got %v", prod["tags"])
+	}
+}
+
+func TestTagExecute_DryRun_AddRemove(t *testing.T) {
+	in := newProductExecInput(t, tagExecFlags, map[string]string{"id": "p-1", "add": "c"}, true)
+	r, err := tagShortcut.Execute(context.Background(), in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Plans) != 2 || r.Plans[0].Method != "GET" || !strings.HasSuffix(r.Plans[0].Path, "/products/p-1") || r.Plans[1].Method != "PUT" {
+		t.Errorf("add/remove should be GET then PUT; got %+v", r.Plans)
+	}
+}
+
+func TestTagExecute_Set_NoGet(t *testing.T) {
+	var gotGet bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			gotGet = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"product": map[string]any{"id": "p-1", "tags": []any{"a"}}})
+	}))
+	defer srv.Close()
+	in := tagInputWithClient(t, map[string]string{"id": "p-1", "set": "x,y"}, srv.URL)
+	if _, err := tagShortcut.Execute(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotGet {
+		t.Error("--set must replace without a GET (no read-merge needed)")
+	}
+}
+
+func TestTagExecute_AddMergesWithExisting(t *testing.T) {
+	var gotPut bool
+	var putTags []any
+	srv := putTagsRecorder(t, []any{"a", "b"}, &gotPut, &putTags)
+	defer srv.Close()
+	in := tagInputWithClient(t, map[string]string{"id": "p-1", "add": "c"}, srv.URL)
+	if _, err := tagShortcut.Execute(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gotPut {
+		t.Fatal("expected a PUT after merging")
+	}
+	if !reflect.DeepEqual(putTags, []any{"a", "b", "c"}) {
+		t.Errorf("PUT tags should keep existing and append; got %v", putTags)
+	}
+}
+
+func TestTagExecute_RemoveDropsTag(t *testing.T) {
+	var gotPut bool
+	var putTags []any
+	srv := putTagsRecorder(t, []any{"a", "b", "c"}, &gotPut, &putTags)
+	defer srv.Close()
+	in := tagInputWithClient(t, map[string]string{"id": "p-1", "remove": "b"}, srv.URL)
+	if _, err := tagShortcut.Execute(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(putTags, []any{"a", "c"}) {
+		t.Errorf("PUT tags should drop removed tag; got %v", putTags)
+	}
+}
+
+func TestTagExecute_NoChangeSkipsPut(t *testing.T) {
+	var gotPut bool
+	var putTags []any
+	srv := putTagsRecorder(t, []any{"a", "b"}, &gotPut, &putTags)
+	defer srv.Close()
+	in := tagInputWithClient(t, map[string]string{"id": "p-1", "add": "b"}, srv.URL)
+	if _, err := tagShortcut.Execute(context.Background(), in); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPut {
+		t.Error("adding an already-present tag must not trigger a PUT")
 	}
 }

--- a/shortcuts/products/plan_test.go
+++ b/shortcuts/products/plan_test.go
@@ -40,8 +40,8 @@ func newProductPlanInput(t *testing.T, tool string, flags map[string]string, val
 
 var productSearchFlags = map[string]string{
 	"keyword": "string", "published": "string", "vendor": "string",
-	"collection-id": "string", "tags": "stringslice",
-	"page-limit": "int", "fields": "stringslice",
+	"collection-id": "string",
+	"page-limit":    "int", "fields": "stringslice",
 }
 
 func TestProductSearchPlan_DefaultsSuccess(t *testing.T) {
@@ -62,10 +62,46 @@ func TestProductSearchPlan_WithKeywordSuccess(t *testing.T) {
 	}
 }
 
+func TestProductSearchPlan_VendorMapsToVendorsArray(t *testing.T) {
+	in := newProductPlanInput(t, "search", productSearchFlags, map[string]string{"vendor": "Acme"})
+	p, err := searchShortcut.Plan(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vs, _ := p.Query["vendors"].([]string)
+	if len(vs) != 1 || vs[0] != "Acme" {
+		t.Errorf("vendor should map to vendors=[Acme]; got query=%v", p.Query)
+	}
+	if _, ok := p.Query["vendor"]; ok {
+		t.Error("must not send the invalid singular `vendor` param")
+	}
+}
+
+func TestProductSearchPlan_PublishedNormalized(t *testing.T) {
+	cases := map[string]string{"true": "published", "false": "unpublished", "any": "any", "published": "published"}
+	for in, want := range cases {
+		pin := newProductPlanInput(t, "search", productSearchFlags, map[string]string{"published": in})
+		p, err := searchShortcut.Plan(pin)
+		if err != nil {
+			t.Fatalf("--published %q: %v", in, err)
+		}
+		if got := p.Query["published_status"]; got != want {
+			t.Errorf("--published %q -> published_status=%v, want %q", in, got, want)
+		}
+	}
+}
+
+func TestProductSearchPlan_PublishedInvalidErrors(t *testing.T) {
+	in := newProductPlanInput(t, "search", productSearchFlags, map[string]string{"published": "yes"})
+	if _, err := searchShortcut.Plan(in); err == nil {
+		t.Error("expected error for an invalid --published value")
+	}
+}
+
 // ── countShortcut.Plan ────────────────────────────────────────────────────────
 
 var productCountFlags = map[string]string{
-	"published": "string", "vendor": "string",
+	"published": "string",
 }
 
 func TestProductCountPlan_DefaultsSuccess(t *testing.T) {
@@ -73,6 +109,21 @@ func TestProductCountPlan_DefaultsSuccess(t *testing.T) {
 	_, err := countShortcut.Plan(in)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestProductCountPlan_PublishedNormalizedAndInvalid(t *testing.T) {
+	in := newProductPlanInput(t, "count", productCountFlags, map[string]string{"published": "false"})
+	p, err := countShortcut.Plan(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Query["published_status"] != "unpublished" {
+		t.Errorf("--published false -> %v, want unpublished", p.Query["published_status"])
+	}
+	bad := newProductPlanInput(t, "count", productCountFlags, map[string]string{"published": "nope"})
+	if _, err := countShortcut.Plan(bad); err == nil {
+		t.Error("expected error for invalid --published")
 	}
 }
 

--- a/shortcuts/products/search.go
+++ b/shortcuts/products/search.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"shoplazza-cli-v2/internal/cmdutil"
+	"shoplazza-cli-v2/internal/output"
 	"shoplazza-cli-v2/shortcuts/common"
 )
 
@@ -13,11 +14,10 @@ var searchShortcut = common.Shortcut{
 	Use:     "+search",
 	Short:   "Quickly search products",
 	Flags: []common.Flag{
-		{Name: "keyword", Type: common.FlagString, Description: "Filter by product title or SKU."},
-		{Name: "published", Type: common.FlagString, Description: "Filter by published status (true|false).", Completions: []string{"true", "false"}},
-		{Name: "vendor", Type: common.FlagString, Description: "Filter by vendor name."},
+		{Name: "keyword", Type: common.FlagString, Description: "Filter by product title."},
+		{Name: "published", Type: common.FlagString, Description: "Filter by published status: published, unpublished, any (true/false also accepted).", Completions: []string{"published", "unpublished", "any"}},
+		{Name: "vendor", Type: common.FlagString, Description: "Filter by vendor name (exact match)."},
 		{Name: "collection-id", Type: common.FlagString, Description: "Filter by collection ID."},
-		{Name: "tags", Type: common.FlagStringSlice, Description: "Filter by tags (comma-separated)."},
 		common.PageLimitFlag(),
 		common.FieldsFlag(),
 	},
@@ -26,14 +26,17 @@ var searchShortcut = common.Shortcut{
 		if err != nil {
 			return common.PlannedRequest{}, err
 		}
+		ps, err := normalizePublishedStatus(in.Flags.GetString("published"))
+		if err != nil {
+			return common.PlannedRequest{}, err
+		}
 		q := map[string]any{}
 		cmdutil.AddString(q, "title", in.Flags.GetString("keyword"))
-		cmdutil.AddString(q, "published_status", in.Flags.GetString("published"))
-		cmdutil.AddString(q, "vendor", in.Flags.GetString("vendor"))
-		cmdutil.AddString(q, "collection_id", in.Flags.GetString("collection-id"))
-		if tags := in.Flags.GetStringSlice("tags"); len(tags) > 0 {
-			q["tags"] = strings.Join(tags, ",")
+		cmdutil.AddString(q, "published_status", ps)
+		if v := strings.TrimSpace(in.Flags.GetString("vendor")); v != "" {
+			q["vendors"] = []string{v} // API param is `vendors` (array), not `vendor`.
 		}
+		cmdutil.AddString(q, "collection_id", in.Flags.GetString("collection-id"))
 		if pl > 0 {
 			q["per_page"] = pl
 		}
@@ -42,4 +45,22 @@ var searchShortcut = common.Shortcut{
 		}
 		return PlanList(q), nil
 	},
+}
+
+// normalizePublishedStatus maps --published to the API's published_status enum
+// (published|unpublished|any). true/false are accepted as aliases; empty means
+// no filter.
+func normalizePublishedStatus(v string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "":
+		return "", nil
+	case "true", "published":
+		return "published", nil
+	case "false", "unpublished":
+		return "unpublished", nil
+	case "any":
+		return "any", nil
+	default:
+		return "", output.ErrValidation("--published must be one of published|unpublished|any (or true/false), got %q", v)
+	}
 }

--- a/shortcuts/products/service.go
+++ b/shortcuts/products/service.go
@@ -64,10 +64,6 @@ func PlanDefaultLocation() common.PlannedRequest {
 	return common.PlannedRequest{Method: "GET", Path: locationsBase + "/default"}
 }
 
-func PlanSetInventoryLevel(body map[string]any) common.PlannedRequest {
-	return common.PlannedRequest{Method: "POST", Path: inventoryLevelsBase + "/set", Body: body}
-}
-
 func PlanAdjustInventoryLevel(body map[string]any) common.PlannedRequest {
 	return common.PlannedRequest{Method: "PUT", Path: inventoryLevelsBase, Body: body}
 }

--- a/shortcuts/products/service_test.go
+++ b/shortcuts/products/service_test.go
@@ -108,14 +108,6 @@ func TestProductPlanDefaultLocation_Shape(t *testing.T) {
 	}
 }
 
-func TestProductPlanSetInventoryLevel_Shape(t *testing.T) {
-	body := map[string]any{"stock": 10}
-	p := PlanSetInventoryLevel(body)
-	if p.Method != "POST" || !strings.HasSuffix(p.Path, "/inventory_levels/set") {
-		t.Errorf("PlanSetInventoryLevel: got Method=%q Path=%q", p.Method, p.Path)
-	}
-}
-
 func TestProductPlanAdjustInventoryLevel_Shape(t *testing.T) {
 	body := map[string]any{"stock_adjustment": 5}
 	p := PlanAdjustInventoryLevel(body)
@@ -144,7 +136,7 @@ func TestProductPlanGetInventoryLevel_Shape(t *testing.T) {
 var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 
 func TestGenerateUniqueToken_IsUUIDv4(t *testing.T) {
-	got := generateUniqueToken("create")
+	got := generateUniqueToken()
 	if !uuidRE.MatchString(got) {
 		t.Errorf("generateUniqueToken = %q, not a valid UUIDv4", got)
 	}
@@ -152,8 +144,8 @@ func TestGenerateUniqueToken_IsUUIDv4(t *testing.T) {
 
 func TestGenerateUniqueToken_Unique(t *testing.T) {
 	seen := map[string]bool{}
-	for i := 0; i < 50; i++ {
-		tok := generateUniqueToken("create")
+	for range 50 {
+		tok := generateUniqueToken()
 		if seen[tok] {
 			t.Fatalf("generateUniqueToken produced duplicate: %q", tok)
 		}

--- a/shortcuts/products/shortcuts.go
+++ b/shortcuts/products/shortcuts.go
@@ -12,5 +12,6 @@ func Shortcuts() []common.Shortcut {
 		createShortcut,
 		setPriceShortcut,
 		stockShortcut,
+		tagShortcut,
 	}
 }

--- a/shortcuts/products/stock.go
+++ b/shortcuts/products/stock.go
@@ -17,6 +17,8 @@ import (
 // --adjust N: direct PUT /inventory_levels with stock_adjustment=N (N must be > 0; the API rejects 0 and negatives).
 // --set N: client-side simulation — GET the current level, compute delta = N - current, then PUT, since the
 // /set endpoint behaves as add (not set). Decrement (N < current) is rejected because the API has no decrement primitive.
+// Verified 2026-06 against staging: POST /inventory_levels/set ADDS despite its "Set" name, and PUT /inventory_levels
+// rejects stock_adjustment ≤ 0 — so neither endpoint can reduce stock. Do not "fix" this by trusting the registry doc.
 var stockShortcut = common.Shortcut{
 	Service: "products",
 	Command: "+stock",
@@ -24,7 +26,7 @@ var stockShortcut = common.Shortcut{
 	Short:   "Set or adjust variant inventory level",
 	Flags: []common.Flag{
 		{Name: "variant-id", Type: common.FlagString, Required: true, Description: "Variant ID (required)."},
-		{Name: "set", Type: common.FlagInt, Description: "Set inventory to an absolute value (≥ 0; mutex with --adjust). Implemented client-side as GET current + PUT delta; decrement is rejected because the API does not support negative stock_adjustment."},
+		{Name: "set", Type: common.FlagInt, Description: "Set inventory to an absolute target (≥ 0; increase only — stock cannot be reduced). Mutually exclusive with --adjust."},
 		{Name: "adjust", Type: common.FlagInt, Description: "Stock delta to add (> 0; the API rejects 0 and negative values). Mutex with --set."},
 		{Name: "location-id", Type: common.FlagString, Description: "Location ID (defaults to default location)."},
 	},

--- a/shortcuts/products/tag.go
+++ b/shortcuts/products/tag.go
@@ -1,0 +1,137 @@
+package products
+
+import (
+	"context"
+	"strings"
+
+	"shoplazza-cli-v2/internal/output"
+	"shoplazza-cli-v2/shortcuts/common"
+)
+
+// tagShortcut edits a product's tags without clobbering the rest.
+//
+// PUT /products/{id} replaces the whole tags array, so adding one tag with the
+// generated command wipes the others. --add/--remove read the current tags,
+// merge, and write back; --set is the explicit full-replace escape hatch.
+var tagShortcut = common.Shortcut{
+	Service: "products",
+	Command: "+tag",
+	Use:     "+tag --id <product-id> (--add a,b | --remove c,d | --set x,y,z)",
+	Short:   "Add or remove product tags without clobbering the existing ones",
+	Flags: []common.Flag{
+		common.IDFlag("Product ID (required)."),
+		{Name: "add", Type: common.FlagStringSlice, Description: "Tags to add (comma-separated); existing tags are kept."},
+		{Name: "remove", Type: common.FlagStringSlice, Description: "Tags to remove (comma-separated); missing tags are ignored."},
+		{Name: "set", Type: common.FlagStringSlice, Description: "Replace all tags with exactly this list (mutually exclusive with --add/--remove)."},
+	},
+	Execute: func(ctx context.Context, in common.ExecInput) (common.ExecResult, error) {
+		id := strings.TrimSpace(in.Flags.GetString("id"))
+		gotSet := in.Flags.Changed("set")
+		gotAdd := in.Flags.Changed("add")
+		gotRemove := in.Flags.Changed("remove")
+
+		if gotSet && (gotAdd || gotRemove) {
+			return common.ExecResult{}, output.ErrValidation("--set replaces all tags; it cannot be combined with --add or --remove")
+		}
+		if !gotSet && !gotAdd && !gotRemove {
+			return common.ExecResult{}, output.ErrValidation("one of --add, --remove, or --set is required")
+		}
+
+		// --set: full replace, so no read-merge is needed.
+		if gotSet {
+			tags := normalizeTags(in.Flags.GetStringSlice("set"))
+			return single(ctx, in, PlanUpdate(id, tagsBody(tags)))
+		}
+
+		// --add/--remove: read current tags, merge, write back.
+		getPlan := PlanGet(id)
+		if in.DryRun {
+			preview := PlanUpdate(id, tagsBody([]string{"<current tags ∪ --add ∖ --remove>"}))
+			return common.ExecResult{Plans: []common.PlannedRequest{getPlan, preview}}, nil
+		}
+		getResp, err := common.Send(ctx, in.Client, getPlan)
+		if err != nil {
+			return common.ExecResult{}, err
+		}
+		current := productTags(getResp)
+		merged := mergeTags(current, in.Flags.GetStringSlice("add"), in.Flags.GetStringSlice("remove"))
+		if equalTags(current, merged) {
+			// Nothing changed: skip the pointless write, echo the product as-is.
+			return common.ExecResult{Body: getResp}, nil
+		}
+		return sendUpdate(ctx, in, PlanUpdate(id, tagsBody(merged)))
+	},
+}
+
+// tagsBody wraps a tag list in the {"product":{"tags":[...]}} update payload.
+func tagsBody(tags []string) map[string]any {
+	return map[string]any{"product": map[string]any{"tags": tags}}
+}
+
+// mergeTags applies remove (against existing) then add, returning a trimmed,
+// deduplicated, order-preserving list. A tag in both --add and --remove ends up
+// present (add wins), since remove only filters the existing set.
+func mergeTags(existing, add, remove []string) []string {
+	removeSet := map[string]bool{}
+	for _, t := range remove {
+		if t = strings.TrimSpace(t); t != "" {
+			removeSet[t] = true
+		}
+	}
+	out := []string{}
+	seen := map[string]bool{}
+	emit := func(tags []string, skipRemoved bool) {
+		for _, t := range tags {
+			t = strings.TrimSpace(t)
+			if t == "" || seen[t] || (skipRemoved && removeSet[t]) {
+				continue
+			}
+			seen[t] = true
+			out = append(out, t)
+		}
+	}
+	emit(existing, true)
+	emit(add, false)
+	return out
+}
+
+// normalizeTags trims, drops empties, and deduplicates while preserving order.
+func normalizeTags(in []string) []string {
+	return mergeTags(in, nil, nil)
+}
+
+// productTags reads product.tags from a `products get` response. JSON decoding
+// yields []any of strings, so it handles both []any and []string.
+func productTags(resp map[string]any) []string {
+	prod, ok := resp["product"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	switch raw := prod["tags"].(type) {
+	case []string:
+		return raw
+	case []any:
+		out := make([]string, 0, len(raw))
+		for _, v := range raw {
+			if s, ok := v.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// equalTags reports whether a and b hold the same tags in the same order.
+func equalTags(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/shortcuts/products/tag_test.go
+++ b/shortcuts/products/tag_test.go
@@ -1,0 +1,79 @@
+package products
+
+import (
+	"reflect"
+	"testing"
+
+	"shoplazza-cli-v2/shortcuts/common"
+)
+
+func TestTagShortcut_ValidationFields(t *testing.T) {
+	if tagShortcut.Service != "products" || tagShortcut.Command != "+tag" {
+		t.Errorf("identity: got %q/%q", tagShortcut.Service, tagShortcut.Command)
+	}
+	if tagShortcut.Execute == nil {
+		t.Fatal("+tag requires Execute (GET current tags, merge, PUT)")
+	}
+	if err := common.ValidateShortcut(tagShortcut); err != nil {
+		t.Errorf("validate: %v", err)
+	}
+}
+
+func TestMergeTags(t *testing.T) {
+	cases := []struct {
+		name                  string
+		existing, add, remove []string
+		want                  []string
+	}{
+		{"add new keeps existing", []string{"a", "b"}, []string{"c"}, nil, []string{"a", "b", "c"}},
+		{"add existing is no dup", []string{"a", "b"}, []string{"b", "c"}, nil, []string{"a", "b", "c"}},
+		{"remove drops one", []string{"a", "b", "c"}, nil, []string{"b"}, []string{"a", "c"}},
+		{"remove missing is ignored", []string{"a"}, nil, []string{"z"}, []string{"a"}},
+		{"add and remove together", []string{"a", "b"}, []string{"c"}, []string{"a"}, []string{"b", "c"}},
+		{"conflict: add wins over remove", []string{"x"}, []string{"y"}, []string{"y"}, []string{"x", "y"}},
+		{"trim and drop empties", []string{"a"}, []string{"  b  ", "", "   "}, nil, []string{"a", "b"}},
+		{"dedup within add", []string{}, []string{"c", "c"}, nil, []string{"c"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mergeTags(c.existing, c.add, c.remove)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("mergeTags(%v,%v,%v) = %v, want %v", c.existing, c.add, c.remove, got, c.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeTags(t *testing.T) {
+	got := normalizeTags([]string{"a", "b", "a", "", "  c  "})
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("normalizeTags = %v, want %v", got, want)
+	}
+}
+
+func TestProductTags(t *testing.T) {
+	// Send decodes JSON arrays as []any, so productTags must handle string-valued []any.
+	resp := map[string]any{"product": map[string]any{"tags": []any{"a", "b"}}}
+	if got := productTags(resp); !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Errorf("productTags = %v, want [a b]", got)
+	}
+	if got := productTags(map[string]any{"product": map[string]any{}}); len(got) != 0 {
+		t.Errorf("productTags(no tags) = %v, want empty", got)
+	}
+	if got := productTags(map[string]any{}); len(got) != 0 {
+		t.Errorf("productTags(no product) = %v, want empty", got)
+	}
+}
+
+func TestEqualTags(t *testing.T) {
+	if !equalTags([]string{"a", "b"}, []string{"a", "b"}) {
+		t.Error("equalTags identical = false")
+	}
+	if equalTags([]string{"a", "b"}, []string{"a", "c"}) {
+		t.Error("equalTags differing = true")
+	}
+	if equalTags([]string{"a"}, []string{"a", "b"}) {
+		t.Error("equalTags different length = true")
+	}
+}


### PR DESCRIPTION
## 概述

对 `products` 模块的快捷命令做了一轮 review,修复了若干"静默发错请求"的 bug,新增一个 `+tag` 命令,并清理死代码。所有 API 行为均对照 2026-01 registry 契约核实;`+stock` 的库存语义在 staging 真机验证过。

> 📌 本 PR **基于 #9 分支**(依赖其中 `+set-price` 重设计引入的内部助手)。请在 #9 合并后再合并本 PR(届时 diff 会自动收敛为仅本 PR 改动)。

---

## 1. 🆕 新增 `+tag` —— 增删标签不覆盖

**场景**:给商品打/去标签。`PUT /products/{id}` 会**整体替换** tags 数组,所以用生成的 `products update --tags x` 加一个标签会**清空原有全部标签**。

| | Before | After (`+tag`) |
|---|---|---|
| 加一个标签 | 必须先查出全部旧标签手动拼好再 PUT,否则全清 | `+tag --id X --add summer` 自动 GET→合并→PUT,保留原有 |
| 删一个标签 | 同上,易误删 | `+tag --id X --remove winter` |
| 整体替换 | `products update --tags ...`(无去重) | `+tag --id X --set a,b,c`(去重,单次 PUT) |

幂等:加已存在 / 删不存在的标签都是 no-op;合并后无变化时**跳过 PUT**。`add`/`remove` 互斥于 `set`,至少给一个。

---

## 2. 🐛 `+search` / `+count` 过滤参数发错(静默失效)

这几个最关键——命令不报错,但过滤条件根本没生效,用户拿到的是全量结果。

### `+search`

| flag | Before(发出的请求) | After |
|---|---|---|
| `--published true` | `published_status=true` ❌(API 枚举是 `published`/`unpublished`/`any`,无效值) | 规范化为 `published_status=published`;`true/false` 仍兼容,非法值直接报错 |
| `--vendor Acme` | `vendor=Acme` ❌(参数名错,应为 `vendors` 数组)→ 静默忽略 | `vendors=["Acme"]` ✅ |
| `--tags x` | `tags=x` ❌(list 端点无此参数)→ 静默忽略 | **移除该 flag**(端点不支持) |
| `--keyword` 描述 | "by title or SKU"(实际只匹配 title) | 修正为 "by title" |

### `+count`

| flag | Before | After |
|---|---|---|
| `--published true` | `published_status=true` ❌ | 规范化,同上 |
| `--vendor X` | `vendor=X` ❌(count 端点根本无 vendor 过滤)→ 静默忽略 | **移除该 flag** |

---

## 3. 🔎 `+stock` 库存语义 —— 真机验证后维持现状

Review 怀疑 `--set` 走了远路:它是 GET 当前值→算 delta→`PUT` 增量,且**拒绝减库存**;而 registry 里有个 `POST /inventory_levels/set`(文档写 "Set inventory level")看起来能绝对赋值。

**在 staging 用一次性商品实测(验完即删)**:

| 调用 | 结果 | 结论 |
|---|---|---|
| 基线库存 10,`POST /set stock=3` | 变成 **13** | `/set` 是**累加**,不是绝对设置(文档误导) |
| `PUT /inventory_levels stock_adjustment=-2` | **400** "must be greater than 0" | 增量不能为负 |

→ 两个写接口都无法减库存,**"不能减"是 API 硬限制,非 CLI 问题**。`--set` 行为**保持不变**,仅在代码里加一行验证结论注释,防止后人再被文档误导去"修"。

---

## 4. 🧹 死代码 / 清理

| 项 | 处理 |
|---|---|
| `PlanSetInventoryLevel`(`POST /inventory_levels/set`) | 无任何命令调用(经第 3 节确认不可用)→ **删除** |
| `PlanGet`(GET 单商品) | review 时是死代码,现被 `+tag` 用上 → **保留** |
| `generateUniqueToken(_ string)` | 去掉被忽略的入参 |

---

## 测试

- `+tag`:纯函数 `mergeTags`/`normalizeTags`/`productTags`/`equalTags` 表驱动测试 + httptest 实跑合并/删除/no-op + dry-run 路由。
- `+search`/`+count`:新增 `published` 规范化(含非法值报错)、`vendor→vendors` 数组的断言。
- `go build ./...` + 全量 `go test ./...` 全绿;改动命令 dry-run 逐条核对。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
