### PR TITLE
app: v1 extension 兼容 + config link 自动激活 + auth login store 校验

### DIFF
--- a/cmd/app/common.go
+++ b/cmd/app/common.go
@@ -25,6 +25,19 @@ func warnWriter(f *cmdutil.Factory) io.Writer {
 	return os.Stderr
 }
 
+// reconcileExtensionApps warns and drops the extension id when a v1 config's
+// owning app (AppID) differs from the deploy target, so it's created fresh.
+func reconcileExtensionApps(w io.Writer, locals []app.LocalExt, activeClientID string) []app.LocalExt {
+	for i := range locals {
+		if locals[i].AppID != "" && locals[i].AppID != activeClientID {
+			fmt.Fprintf(w, "warning: extension %q was created under app %s; deploying to %s creates it as a NEW extension here (its old id is ignored)\n",
+				locals[i].Name, locals[i].AppID, activeClientID)
+			locals[i].ExtensionID = ""
+		}
+	}
+	return locals
+}
+
 // requireLogin is the light app gate: only verifies "logged in (has UAT)".
 // It does NOT require a current store (unlike cmdutil.RequireAuth).
 func requireLogin(ctx context.Context, f *cmdutil.Factory) error {

--- a/cmd/app/common_test.go
+++ b/cmd/app/common_test.go
@@ -450,3 +450,35 @@ func TestEnsurePartnerID(t *testing.T) {
 		t.Fatalf("unresolvable partner: ex=%v (want validation error)", ex)
 	}
 }
+
+func TestReconcileExtensionApps(t *testing.T) {
+	// Mismatch: warns and drops the cross-app id so it deploys as new.
+	var buf bytes.Buffer
+	got := reconcileExtensionApps(&buf, []app.LocalExt{
+		{Name: "preorder", Type: "theme", ExtensionID: "657", AppID: "app_ff"},
+	}, "app_xuxu")
+	if got[0].ExtensionID != "" {
+		t.Errorf("cross-app id should be dropped, got %q", got[0].ExtensionID)
+	}
+	if !strings.Contains(buf.String(), "preorder") || !strings.Contains(buf.String(), "app_ff") {
+		t.Errorf("expected a cross-app warning naming the extension and its app, got %q", buf.String())
+	}
+
+	// Same app: keep the id, no warning.
+	buf.Reset()
+	got = reconcileExtensionApps(&buf, []app.LocalExt{
+		{Name: "co", ExtensionID: "777", AppID: "app_xuxu"},
+	}, "app_xuxu")
+	if got[0].ExtensionID != "777" || buf.Len() != 0 {
+		t.Errorf("same-app should keep id and not warn; id=%q warn=%q", got[0].ExtensionID, buf.String())
+	}
+
+	// v2 toml (no AppID): unchanged, no warning.
+	buf.Reset()
+	got = reconcileExtensionApps(&buf, []app.LocalExt{
+		{Name: "v2", ExtensionID: "999"},
+	}, "app_xuxu")
+	if got[0].ExtensionID != "999" || buf.Len() != 0 {
+		t.Errorf("v2 ext should be untouched; id=%q warn=%q", got[0].ExtensionID, buf.String())
+	}
+}

--- a/cmd/app/config.go
+++ b/cmd/app/config.go
@@ -109,7 +109,11 @@ func runConfigLink(ctx context.Context, d *app.Dashboard, p *project.Project, o 
 		}
 		return output.ErrInternal("failed to write %s: %v", configName, err)
 	}
-	return output.PrintBody(w, map[string]any{"config": configName, "client_id": ref.ClientID, "partner_id": ref.PartnerID}, format, jq)
+	// Linking implies "use this app now" — activate it (client_id already validated).
+	if err := p.SetActiveConfig(configName, ref.ClientID); err != nil {
+		return output.ErrInternal("failed to write app-state: %v", err)
+	}
+	return output.PrintBody(w, map[string]any{"config": configName, "active_config": configName, "client_id": ref.ClientID, "partner_id": ref.PartnerID}, format, jq)
 }
 
 // configFileForName maps a config name segment to its toml filename

--- a/cmd/app/config_test.go
+++ b/cmd/app/config_test.go
@@ -111,6 +111,13 @@ func TestRunConfigLink_LinkExisting(t *testing.T) {
 	if cfg.PartnerID != "p1" {
 		t.Fatalf("partner_id not persisted into config: got %q, want p1", cfg.PartnerID)
 	}
+	// link auto-activates the linked config.
+	if active, _ := p.ActiveConfigName(); active != "shoplazza.app.prod.toml" {
+		t.Fatalf("link should activate the config, got active=%q", active)
+	}
+	if !strings.Contains(buf.String(), "active_config") {
+		t.Fatalf("output should report active_config, got %s", buf.String())
+	}
 }
 
 func TestRunConfigLink_CreateNew(t *testing.T) {
@@ -136,6 +143,9 @@ func TestRunConfigLink_CreateNew(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(root, "shoplazza.app.dev.toml")); statErr != nil {
 		t.Fatalf("config file not written: %v", statErr)
+	}
+	if active, _ := p.ActiveConfigName(); active != "shoplazza.app.dev.toml" {
+		t.Fatalf("create+link should activate the config, got active=%q", active)
 	}
 }
 

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -78,6 +78,9 @@ func newCmdDeploy(f *cmdutil.Factory) *cobra.Command {
 			if scanErr != nil {
 				return scanErr
 			}
+			// v1-compat: warn + drop ids for extensions whose legacy config names a
+			// different app than the one being deployed to.
+			locals = reconcileExtensionApps(warnWriter(f), locals, cid)
 
 			res, ex := app.Deploy(ctx, app.DeployDeps{
 				Dashboard:   d,

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -110,6 +110,9 @@ func newCmdLogin(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			fmt.Fprintf(f.IOStreams.ErrOut, "\nOK: Login successful!\n")
+			if result.StoreWarning != "" {
+				fmt.Fprintf(f.IOStreams.ErrOut, "  warning: %s\n", result.StoreWarning)
+			}
 			if result.Status.CurrentStore != "" {
 				fmt.Fprintf(f.IOStreams.ErrOut, "  Current store: %s\n", result.Status.CurrentStore)
 			}
@@ -118,13 +121,17 @@ func newCmdLogin(f *cmdutil.Factory) *cobra.Command {
 			}
 			fmt.Fprintf(f.IOStreams.ErrOut, "  UAT: %s\n", result.UAT)
 
-			return output.PrintJSON(cmd.OutOrStdout(), map[string]any{
+			out := map[string]any{
 				"ok":     true,
 				"action": "login",
 				"flow":   result.Flow,
 				"uat":    result.UAT,
 				"status": result.Status,
-			})
+			}
+			if result.StoreWarning != "" {
+				out["store_warning"] = result.StoreWarning
+			}
+			return output.PrintJSON(cmd.OutOrStdout(), out)
 		},
 	}
 

--- a/internal/app/build.go
+++ b/internal/app/build.go
@@ -154,6 +154,11 @@ func BuildArtifactFor(ctx context.Context, projectRoot string, l LocalExt, debug
 		return buildCheckout(ctx, projectRoot, l.Dir, debug)
 	case "theme":
 		src := filepath.Join(projectRoot, "extensions", l.Dir)
+		// v1 nests theme content under theme-app/; zip that subdir so the archive
+		// isn't double-nested (theme-app/theme-app/...). v2 (flat) has no such subdir.
+		if sub := filepath.Join(src, "theme-app"); isDir(sub) {
+			src = sub
+		}
 		// Content/time-unique name (v1 parity) — a static name collides with the
 		// overwrite-forbidden OSS object and silently reuses a stale artifact.
 		zipName, nErr := themeZipName(src, l.Name)
@@ -178,6 +183,12 @@ func BuildArtifactFor(ctx context.Context, projectRoot string, l LocalExt, debug
 	default:
 		return "", output.ErrValidation("unknown extension type %q in %s", l.Type, l.Dir)
 	}
+}
+
+// isDir reports whether path exists and is a directory.
+func isDir(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.IsDir()
 }
 
 // functionEntryPath returns the JS entry for a function extension:

--- a/internal/app/build_test.go
+++ b/internal/app/build_test.go
@@ -88,6 +88,46 @@ func TestThemeZipName_Deterministic_SameContent(t *testing.T) {
 	}
 }
 
+// TestBuildArtifactFor_Theme_V1NestedLayout: a v1 extension nests the theme
+// content under theme-app/ (alongside extension.config.json). The zip must root
+// the CONTENT at theme-app/ (so the backend finds theme-app/assets-manifest.json),
+// not double-nest it (theme-app/theme-app/...) or include the v1 metadata.
+func TestBuildArtifactFor_Theme_V1NestedLayout(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "preorder")
+	themeApp := filepath.Join(extDir, "theme-app")
+	os.MkdirAll(filepath.Join(themeApp, "blocks"), 0o755)
+	os.WriteFile(filepath.Join(themeApp, "assets-manifest.json"), []byte("{}"), 0o644)
+	os.WriteFile(filepath.Join(themeApp, "blocks", "a.liquid"), []byte("x"), 0o644)
+	// v1 metadata at the extension root — must NOT end up in the theme bundle.
+	os.WriteFile(filepath.Join(extDir, "extension.config.json"), []byte("{}"), 0o644)
+
+	got, exitErr := BuildArtifactFor(context.Background(), root, LocalExt{
+		Dir: "preorder", Name: "preorder", Type: "theme",
+	}, false)
+	if exitErr != nil {
+		t.Fatalf("BuildArtifactFor: %v", exitErr)
+	}
+	zr, err := zip.OpenReader(got)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer zr.Close()
+	found := map[string]bool{}
+	for _, f := range zr.File {
+		found[f.Name] = true
+	}
+	if !found["theme-app/assets-manifest.json"] || !found["theme-app/blocks/a.liquid"] {
+		t.Fatalf("content must be rooted at theme-app/: %v", found)
+	}
+	if found["theme-app/theme-app/assets-manifest.json"] {
+		t.Fatalf("must not double-nest theme-app/: %v", found)
+	}
+	if found["theme-app/extension.config.json"] {
+		t.Fatalf("v1 metadata must not be bundled: %v", found)
+	}
+}
+
 func TestBuildArtifactFor_UnknownType_Errors(t *testing.T) {
 	_, exitErr := BuildArtifactFor(context.Background(), t.TempDir(), LocalExt{
 		Dir: "myext", Name: "myext", Type: "unknown-type",

--- a/internal/app/deploy.go
+++ b/internal/app/deploy.go
@@ -284,9 +284,16 @@ func buildUploadUpsert(ctx context.Context, deps DeployDeps) ([]DeployedExt, str
 		// Persist the server-issued id into the extension toml so the NEXT
 		// dev/deploy id-matches instead of re-creating (v1 deploy.js:156 /
 		// dev.js:154). Only on change — the common update path stays write-free.
-		if got := deployed[len(deployed)-1].ExtensionID; got != "" && got != p.Local.ExtensionID && deps.ProjectRoot != "" {
-			if wErr := WriteBackExtensionVersion(deps.ProjectRoot, p.Local.Dir, got, ""); wErr != nil {
-				return nil, "", wrapExtErr(p.Local, output.ErrInternal("upsert succeeded but writing back extension id failed: %v", wErr))
+		if got := deployed[len(deployed)-1].ExtensionID; got != "" && deps.ProjectRoot != "" {
+			if got != p.Local.ExtensionID {
+				if wErr := WriteBackExtensionVersion(deps.ProjectRoot, p.Local.Dir, got, ""); wErr != nil {
+					return nil, "", wrapExtErr(p.Local, output.ErrInternal("upsert succeeded but writing back extension id failed: %v", wErr))
+				}
+			}
+			// v1-compat: migrate a legacy extension.config.json to a v2 toml. No-op otherwise.
+			ext := deployed[len(deployed)-1]
+			if mErr := MigrateV1Extension(deps.ProjectRoot, p.Local.Dir, got, ext.Name, ext.Type, ext.Version); mErr != nil {
+				return nil, "", wrapExtErr(p.Local, output.ErrInternal("upsert succeeded but migrating v1 config failed: %v", mErr))
 			}
 		}
 	}

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -15,6 +15,7 @@ type LocalExt struct {
 	Type        string
 	Version     string // optional; from the extension toml. Diff ignores it.
 	ExtensionID string // optional; set once known
+	AppID       string // v1 extension.config.json `appId`; empty for v2. Diff ignores it.
 }
 
 // Pair maps a local extension to its remote counterpart. Remote is nil when the

--- a/internal/app/scan.go
+++ b/internal/app/scan.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -17,6 +18,16 @@ type scanExtToml struct {
 	Name    string `toml:"name"`
 	Type    string `toml:"type"`
 	Version string `toml:"version"`
+}
+
+// v1ExtConfig is the subset of the legacy v1 extension.config.json the scanner
+// reads as a fallback when no v2 toml is present.
+type v1ExtConfig struct {
+	ExtensionID   string `json:"extensionId"`
+	AppID         string `json:"appId"`
+	ExtensionName string `json:"extensionName"`
+	Version       string `json:"version"`
+	Type          string `json:"type"`
 }
 
 // ScanLocalExtensions reads <root>/extensions/*/shoplazza.extension.toml and
@@ -40,21 +51,51 @@ func ScanLocalExtensions(root string) ([]LocalExt, *output.ExitError) {
 			continue
 		}
 		var et scanExtToml
-		if _, err := toml.DecodeFile(filepath.Join(dir, e.Name(), "shoplazza.extension.toml"), &et); err != nil {
-			// toml.DecodeFile on a missing file returns a *fs.PathError that
-			// satisfies os.ErrNotExist — that's a non-extension dir, skip it.
-			if errors.Is(err, os.ErrNotExist) {
-				continue
-			}
+		_, err := toml.DecodeFile(filepath.Join(dir, e.Name(), "shoplazza.extension.toml"), &et)
+		if err == nil {
+			out = append(out, LocalExt{
+				Dir:         e.Name(),
+				Name:        et.Name,
+				Type:        et.Type,
+				Version:     et.Version,
+				ExtensionID: et.ID,
+			})
+			continue
+		}
+		if !errors.Is(err, os.ErrNotExist) {
 			return nil, output.ErrValidation("extensions/%s/shoplazza.extension.toml is malformed: %v", e.Name(), err)
+		}
+
+		// No v2 toml — fall back to the legacy v1 extension.config.json.
+		v1, vErr := readV1ExtConfig(filepath.Join(dir, e.Name(), "extension.config.json"))
+		if vErr != nil {
+			if errors.Is(vErr, os.ErrNotExist) {
+				continue // neither v2 nor v1: not an extension dir, skip
+			}
+			return nil, output.ErrValidation("extensions/%s/extension.config.json is malformed: %v", e.Name(), vErr)
 		}
 		out = append(out, LocalExt{
 			Dir:         e.Name(),
-			Name:        et.Name,
-			Type:        et.Type,
-			Version:     et.Version,
-			ExtensionID: et.ID,
+			Name:        v1.ExtensionName,
+			Type:        v1.Type,
+			Version:     v1.Version,
+			ExtensionID: v1.ExtensionID,
+			AppID:       v1.AppID,
 		})
 	}
 	return out, nil
+}
+
+// readV1ExtConfig reads a legacy v1 extension.config.json. A missing file
+// returns an error satisfying os.ErrNotExist (so the caller can skip).
+func readV1ExtConfig(path string) (v1ExtConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return v1ExtConfig{}, err
+	}
+	var c v1ExtConfig
+	if err := json.Unmarshal(data, &c); err != nil {
+		return v1ExtConfig{}, err
+	}
+	return c, nil
 }

--- a/internal/app/scan_test.go
+++ b/internal/app/scan_test.go
@@ -66,6 +66,77 @@ func TestScanLocalExtensions_DirWithoutToml_Skipped(t *testing.T) {
 	}
 }
 
+// TestScanLocalExtensions_V1Fallback: a dir with only the legacy v1
+// extension.config.json (no v2 toml) is read and mapped to LocalExt, so v1
+// projects deploy without a manual migration.
+func TestScanLocalExtensions_V1Fallback(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "preorder")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v1 := `{"extensionId":"657218221862028613","appId":"app_x","partnerId":"3665","extensionName":"preorder","version":"1.0.0","type":"theme","subtype":"basic"}`
+	if err := os.WriteFile(filepath.Join(extDir, "extension.config.json"), []byte(v1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	locals, err := ScanLocalExtensions(root)
+	if err != nil {
+		t.Fatalf("ScanLocalExtensions: %v", err)
+	}
+	if len(locals) != 1 {
+		t.Fatalf("locals = %+v, want 1", locals)
+	}
+	got := locals[0]
+	if got.ExtensionID != "657218221862028613" || got.Name != "preorder" || got.Type != "theme" || got.Version != "1.0.0" || got.AppID != "app_x" {
+		t.Fatalf("v1 mapping wrong: %+v", got)
+	}
+}
+
+// TestScanLocalExtensions_V2TomlWinsOverV1: when both formats are present, the
+// v2 toml is authoritative and the v1 json is ignored.
+func TestScanLocalExtensions_V2TomlWinsOverV1(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "co")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "shoplazza.extension.toml"),
+		[]byte("id = \"v2id\"\nname = \"co\"\ntype = \"checkout\"\nversion = \"2.0.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "extension.config.json"),
+		[]byte(`{"extensionId":"v1id","extensionName":"co","type":"checkout","version":"1.0.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	locals, err := ScanLocalExtensions(root)
+	if err != nil {
+		t.Fatalf("ScanLocalExtensions: %v", err)
+	}
+	if len(locals) != 1 || locals[0].ExtensionID != "v2id" || locals[0].AppID != "" {
+		t.Fatalf("toml should win: %+v", locals)
+	}
+}
+
+// TestScanLocalExtensions_V1Malformed_Validation: a present but unparseable v1
+// json surfaces as a validation error naming the file, like the toml path.
+func TestScanLocalExtensions_V1Malformed_Validation(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "bad")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "extension.config.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ScanLocalExtensions(root)
+	if err == nil {
+		t.Fatal("expected validation error for malformed v1 config")
+	}
+	if err.Code != output.ExitValidation || !strings.Contains(err.Error(), "extensions/bad/extension.config.json") {
+		t.Fatalf("error should name the v1 file as validation, got %q (code %d)", err.Error(), err.Code)
+	}
+}
+
 // TestScanLocalExtensions_MalformedToml_Validation: a present but
 // unparseable extension toml must surface as a validation error naming the
 // file — silently skipping it made deploy/dev quietly ignore the extension.

--- a/internal/app/writeback.go
+++ b/internal/app/writeback.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -42,4 +43,66 @@ func WriteBackExtensionVersion(root, dir, id, version string) error {
 		return err
 	}
 	return fsx.WriteFileAtomic(path, buf.Bytes(), 0o644)
+}
+
+// deprecationNotice marks a migrated v1 extension.config.json (JSON has no comments).
+const deprecationNotice = "DEPRECATED: superseded by shoplazza.extension.toml (v2). The CLI no longer reads this file."
+
+// MigrateV1Extension writes a v2 shoplazza.extension.toml (with the deployed id)
+// for a legacy extension.config.json and marks the json deprecated (kept, not
+// deleted). appId/partnerId are not carried over. No-op when there's no v1 json.
+func MigrateV1Extension(root, dir, id, name, typ, version string) error {
+	extDir := filepath.Join(root, project.ExtensionsDir, dir)
+	jsonPath := filepath.Join(extDir, "extension.config.json")
+	if _, err := os.Stat(jsonPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // no v1 json → nothing to migrate
+		}
+		return err
+	}
+
+	// Write the v2 toml unless one already exists (then the write-back owns it).
+	tomlPath := filepath.Join(extDir, "shoplazza.extension.toml")
+	if _, err := os.Stat(tomlPath); errors.Is(err, os.ErrNotExist) {
+		m := map[string]any{"name": name, "type": typ}
+		if id != "" {
+			m["id"] = id
+		}
+		if version != "" {
+			m["version"] = version
+		}
+		var buf bytes.Buffer
+		if err := toml.NewEncoder(&buf).Encode(m); err != nil {
+			return err
+		}
+		if err := fsx.WriteFileAtomic(tomlPath, buf.Bytes(), 0o644); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return deprecateV1Config(jsonPath)
+}
+
+// deprecateV1Config adds a `_deprecated` notice to the v1 json, preserving its
+// other keys. Idempotent: an already-marked file is left untouched.
+func deprecateV1Config(jsonPath string) error {
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		return err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	if _, ok := m["_deprecated"]; ok {
+		return nil
+	}
+	m["_deprecated"] = deprecationNotice
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return fsx.WriteFileAtomic(jsonPath, append(out, '\n'), 0o644)
 }

--- a/internal/app/writeback_test.go
+++ b/internal/app/writeback_test.go
@@ -1,0 +1,127 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestMigrateV1Extension_WritesTomlAndDeprecatesJSON(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "preorder")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jsonPath := filepath.Join(extDir, "extension.config.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"extensionId":"old","appId":"ff","partnerId":"3665"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigrateV1Extension(root, "preorder", "newid", "preorder", "theme", "1.0.0"); err != nil {
+		t.Fatalf("MigrateV1Extension: %v", err)
+	}
+
+	// v1 json is KEPT, with a _deprecated notice added and original keys intact.
+	jb, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("json should be kept: %v", err)
+	}
+	var jm map[string]any
+	if err := json.Unmarshal(jb, &jm); err != nil {
+		t.Fatalf("json should stay valid: %v", err)
+	}
+	if _, ok := jm["_deprecated"]; !ok {
+		t.Errorf("json should gain a _deprecated marker, got %v", jm)
+	}
+	if jm["extensionId"] != "old" {
+		t.Errorf("original json keys must be preserved, got %v", jm)
+	}
+	// v2 toml written with the NEW id and name/type; no appId/partnerId.
+	var m map[string]any
+	if _, err := toml.DecodeFile(filepath.Join(extDir, "shoplazza.extension.toml"), &m); err != nil {
+		t.Fatalf("decode toml: %v", err)
+	}
+	if m["id"] != "newid" || m["name"] != "preorder" || m["type"] != "theme" {
+		t.Errorf("toml = %v, want id=newid name=preorder type=theme", m)
+	}
+	if _, ok := m["appId"]; ok {
+		t.Errorf("v2 toml must not carry appId: %v", m)
+	}
+	if _, ok := m["partnerId"]; ok {
+		t.Errorf("v2 toml must not carry partnerId: %v", m)
+	}
+}
+
+func TestMigrateV1Extension_Idempotent(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "preorder")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jsonPath := filepath.Join(extDir, "extension.config.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"extensionId":"old"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateV1Extension(root, "preorder", "newid", "preorder", "theme", "1.0.0"); err != nil {
+		t.Fatal(err)
+	}
+	first, _ := os.ReadFile(jsonPath)
+	if err := MigrateV1Extension(root, "preorder", "newid", "preorder", "theme", "1.0.0"); err != nil {
+		t.Fatal(err)
+	}
+	second, _ := os.ReadFile(jsonPath)
+	if string(first) != string(second) {
+		t.Errorf("re-migration should not rewrite an already-deprecated json")
+	}
+}
+
+func TestMigrateV1Extension_NoJSON_NoOp(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "v2only")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateV1Extension(root, "v2only", "id", "v2only", "theme", ""); err != nil {
+		t.Fatalf("MigrateV1Extension: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(extDir, "shoplazza.extension.toml")); !os.IsNotExist(err) {
+		t.Errorf("no v1 json → must not create a toml; stat err=%v", err)
+	}
+}
+
+func TestMigrateV1Extension_TomlExists_KeepsTomlMarksJSON(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "both")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jsonPath := filepath.Join(extDir, "extension.config.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"extensionId":"old"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tomlPath := filepath.Join(extDir, "shoplazza.extension.toml")
+	if err := os.WriteFile(tomlPath, []byte("id=\"keep\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateV1Extension(root, "both", "newid", "both", "theme", ""); err != nil {
+		t.Fatalf("MigrateV1Extension: %v", err)
+	}
+	// toml present → write-back owns it, so it's not overwritten here.
+	var m map[string]any
+	if _, err := toml.DecodeFile(tomlPath, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["id"] != "keep" {
+		t.Errorf("existing toml must not be overwritten, got id=%v", m["id"])
+	}
+	// json still gets the deprecation marker.
+	jb, _ := os.ReadFile(jsonPath)
+	var jm map[string]any
+	_ = json.Unmarshal(jb, &jm)
+	if _, ok := jm["_deprecated"]; !ok {
+		t.Errorf("json should be marked deprecated even when a toml already exists: %v", jm)
+	}
+}

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -71,14 +71,35 @@ func (m *Manager) Login(ctx context.Context, storeDomain string, scopes []string
 			continue
 		case "ok":
 			state := stateFromPoll(pollRes, storeDomain)
+			warning := ""
+			// Validate the requested store now (post-consent) unless the session
+			// pre-warmed its token; a bad store is reported, not set as current.
+			if storeDomain != "" && pollRes.StoreToken == nil {
+				if block, sErr := m.exchangeStoreAT(ctx, pollRes.UAT, storeDomain); sErr != nil {
+					state.CurrentStore = ""
+					warning = storeValidationWarning(storeDomain, sErr)
+				} else {
+					applyStoreToken(&state, block, storeDomain)
+				}
+			}
 			if err := m.persistState(state); err != nil {
 				return LoginResult{Flow: "web", AuthorizeURL: session.AuthorizeURL}, err
 			}
-			return LoginResult{Flow: "web", UAT: pollRes.UAT, AuthorizeURL: session.AuthorizeURL, Status: statusFromState(state)}, nil
+			return LoginResult{Flow: "web", UAT: pollRes.UAT, AuthorizeURL: session.AuthorizeURL, Status: statusFromState(state), StoreWarning: warning}, nil
 		default:
 			return LoginResult{Flow: "web", AuthorizeURL: session.AuthorizeURL}, errors.New("unexpected session status: " + pollRes.Status)
 		}
 	}
+}
+
+// storeValidationWarning renders the login-time message for a store that failed
+// validation. A 404 means the domain doesn't exist or isn't accessible.
+func storeValidationWarning(domain string, err error) string {
+	var he *client.HTTPError
+	if errors.As(err, &he) && he.StatusCode == 404 {
+		return fmt.Sprintf("store %q not found or not accessible — not set as current store", domain)
+	}
+	return fmt.Sprintf("could not validate store %q (%v) — not set as current store", domain, err)
 }
 
 // applyStoreToken records a freshly minted store token in state, keyed by the

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -37,9 +37,10 @@ func newTestManager(t *testing.T, srv *httptest.Server) *internalauth.Manager {
 }
 
 type brokerOpts struct {
-	pendingPolls int
-	okBody       map[string]any
-	storeAT      map[string]any
+	pendingPolls  int
+	okBody        map[string]any
+	storeAT       map[string]any
+	storeATStatus int // when non-zero and != 200, store-at responds with this status
 }
 
 // brokerServer mocks the auth backend for the interactive web flow: pending → ok,
@@ -62,6 +63,11 @@ func brokerServer(t *testing.T, opts brokerOpts) *httptest.Server {
 		case r.URL.Path == "/api/saiga/cli/auth/me":
 			json.NewEncoder(w).Encode(map[string]any{"user_id": "u1", "account": "alice@example.com"})
 		case r.URL.Path == "/api/saiga/cli/auth/exchange/store-at":
+			if opts.storeATStatus != 0 && opts.storeATStatus != http.StatusOK {
+				w.WriteHeader(opts.storeATStatus)
+				w.Write([]byte(`{"code":"store_not_found","errors":["store not found"]}`))
+				return
+			}
 			json.NewEncoder(w).Encode(opts.storeAT)
 		default:
 			t.Errorf("unexpected path: %s", r.URL.Path)
@@ -126,9 +132,12 @@ func TestLogin_WithStoreDomain_PrewarmsStoreToken(t *testing.T) {
 	}
 }
 
-func TestLogin_WithStoreDomain_PrewarmMissing_StillSetsCurrentStore(t *testing.T) {
+// When the session omits a prewarmed store_token, login validates the store via
+// an explicit store-at exchange; a valid store gets set + its token cached.
+func TestLogin_WithStoreDomain_PrewarmMissing_ValidatesViaExchange(t *testing.T) {
 	srv := brokerServer(t, brokerOpts{
-		okBody: map[string]any{"status": "ok", "uat": "uat_s", "account": "a@x.com"}, // no store_token
+		okBody:  map[string]any{"status": "ok", "uat": "uat_s", "account": "a@x.com"}, // no store_token
+		storeAT: map[string]any{"access_token": "at_validated", "store_id": "7", "store_domain": "my-store.com", "granted_scopes": []string{"read_product"}, "at_expires_at": "2099-01-01T00:00:00Z"},
 	})
 	defer srv.Close()
 	mgr := newTestManager(t, srv)
@@ -137,12 +146,41 @@ func TestLogin_WithStoreDomain_PrewarmMissing_StillSetsCurrentStore(t *testing.T
 	if err != nil {
 		t.Fatalf("Login: %v", err)
 	}
-	if res.Status.CurrentStore != "my-store.com" {
-		t.Errorf("current store should be set even when prewarm omits store_token; got %q", res.Status.CurrentStore)
+	if res.Status.CurrentStore != "my-store.com" || res.StoreWarning != "" {
+		t.Errorf("valid store should be set with no warning; current=%q warn=%q", res.Status.CurrentStore, res.StoreWarning)
 	}
 	st, _ := mgr.LoadState()
-	if _, ok := st.Stores["my-store.com"]; ok {
-		t.Errorf("no store token expected when prewarm omitted it")
+	if st.Stores["my-store.com"].Token != "at_validated" {
+		t.Errorf("validated store token should be cached, got %q", st.Stores["my-store.com"].Token)
+	}
+}
+
+// A bad/inaccessible --store-domain (store-at 404) does not fail login: it warns
+// and leaves the store unset, and the bad domain is never persisted.
+func TestLogin_WithStoreDomain_ValidationFails_WarnsAndUnsets(t *testing.T) {
+	srv := brokerServer(t, brokerOpts{
+		okBody:        map[string]any{"status": "ok", "uat": "uat_s", "account": "a@x.com"}, // no store_token
+		storeATStatus: http.StatusNotFound,
+	})
+	defer srv.Close()
+	mgr := newTestManager(t, srv)
+
+	res, err := mgr.Login(context.Background(), "bad-store.com", nil, "", 5*time.Second, time.Millisecond, nil)
+	if err != nil {
+		t.Fatalf("login should still succeed on a bad store: %v", err)
+	}
+	if res.Status.CurrentStore != "" {
+		t.Errorf("bad store must not be set as current, got %q", res.Status.CurrentStore)
+	}
+	if !strings.Contains(res.StoreWarning, "bad-store.com") {
+		t.Errorf("expected a store warning naming the domain, got %q", res.StoreWarning)
+	}
+	st, _ := mgr.LoadState()
+	if st.CurrentStore != "" || len(st.Stores) != 0 {
+		t.Errorf("bad store must not be persisted: current=%q stores=%v", st.CurrentStore, st.Stores)
+	}
+	if st.UAT != "uat_s" {
+		t.Errorf("login (UAT) should still persist, got %q", st.UAT)
 	}
 }
 

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -95,6 +95,9 @@ type LoginResult struct {
 	UAT          string
 	AuthorizeURL string // non-empty for web flow
 	Status       Status
+	// StoreWarning is set when a requested --store-domain fails validation at
+	// login; login still succeeds but the store is not set as current.
+	StoreWarning string
 }
 
 // ── HTTP request / response types ────────────────────────────────────────────

--- a/shortcuts/products/stock.go
+++ b/shortcuts/products/stock.go
@@ -16,9 +16,7 @@ import (
 //
 // --adjust N: direct PUT /inventory_levels with stock_adjustment=N (N must be > 0; the API rejects 0 and negatives).
 // --set N: client-side simulation — GET the current level, compute delta = N - current, then PUT, since the
-// /set endpoint behaves as add (not set). Decrement (N < current) is rejected because the API has no decrement primitive.
-// Verified 2026-06 against staging: POST /inventory_levels/set ADDS despite its "Set" name, and PUT /inventory_levels
-// rejects stock_adjustment ≤ 0 — so neither endpoint can reduce stock. Do not "fix" this by trusting the registry doc.
+// /set endpoint behaves as add (not set). Decrement (N < current) is rejected: the API has no decrement primitive.
 var stockShortcut = common.Shortcut{
 	Service: "products",
 	Command: "+stock",


### PR DESCRIPTION
## 概述

三块 app/auth 相关改动,面向 v1 老项目迁移 + 登录/配置体验:

### 1. v1 extension 兼容(deploy)
老的 v1 项目用 `extensions/<dir>/extension.config.json`(JSON、且 theme 内容嵌套在 `theme-app/` 子目录),v2 deploy 只认 `shoplazza.extension.toml`,会**静默跳过**它们。现修复:
- 扫描器在没有 toml 时回退读 `extension.config.json`(映射 id/name/type/version + appId)→ v1 extension 能被 deploy 识别。
- extension 归属的 app(appId)与部署目标不一致时,**warn 并丢弃旧 id**,在目标 app 下新建而非张冠李戴。
- theme 打包:存在 `theme-app/` 子目录时打包该子目录,避免 `theme-app/theme-app/` 双层嵌套导致后端建版本任务找不到 `assets-manifest.json`。
- 部署后把 v1 config 迁移成 v2 toml(带新 id),并给旧 json 打 `_deprecated` 标记(**保留、不删**)。

### 2. `app config link` 自动激活
以前 `link` 只写 toml,还得再跑一次 `config use` 才生效。现在 `link` 直接把它设为当前配置(client_id 已验证,无额外网络请求),输出含 `active_config`。

### 3. `auth login` 登录时校验 store 域名
交互式登录以前乐观地把 store 域名落盘,坏域名/无权限只会在**以后某条命令**上撞出莫名其妙的 `404 store_not_found`。现在:会话未预热 store token 时,登录当下就用 `store-at` 换取校验(和 `auth store use` 同一接口)。**失败不使登录失败**——只是不设为当前店 + 返回警告(登录/UAT 照常保留);成功则缓存 token。`--uat` 和 `auth store use` 本就这样校验。
> 说明:校验发生在浏览器授权之后(OAuth 决定了授权链接生成时后端还不知道用户身份,无法做归属校验)。"授权前拦截"需要 saiga+totoro 新增无用户的按域名查店接口,已单列、不在本 PR。

## 质量
- 每块都有测试:scan v1 回退 / theme 嵌套布局 / migrate+deprecate / reconcile 跨 app / config link 自动激活断言 / 登录 store 校验(成功缓存、404 警告且不落盘)。
- 全量 `go test ./...` 全绿;`go vet` 干净。所有面向用户注释按项目规范精简(公开仓库)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
