### PR TITLE
Release 2.0.4: app extension v1 compat, auth fixes, analytics metadata refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`app deploy` v1 extension compatibility** — recognizes legacy `extension.config.json` extensions, handles the nested `theme-app/` theme layout, warns when an extension's config names a different app than the deploy target, and migrates v1 configs to `shoplazza.extension.toml` on deploy (marking the old JSON deprecated rather than deleting it).
+- `app config link` now auto-activates the linked config — no separate `app config use` step needed.
+
+### Changed
+- `theme-extension connect` no longer needs `--partner`: it derives the app's partner from `--client-id` (consistent with `theme-extension release` and `app config link`). The `--partner` flag was removed.
+- `auth status` / `auth login` always include `current_store` (empty `""` when no store is selected), consistent with `granted_scopes`.
+
+### Fixed
+- `auth login --store-domain` now validates the store at login: an invalid or inaccessible store yields a clear warning and is not set as the current store, instead of surfacing later as a confusing `404 store_not_found`. Login itself still succeeds.
+- `auth login` no longer prints the store warning twice (stderr summary only, not repeated in the JSON).
+
+## 2.0.3 - 2026-06-26
+
+Products shortcut hardening.
+
+### Added
+- **`products +tag`** — add, remove, or replace a product's tags without clobbering the others (`--add` / `--remove` / `--set`).
+
+### Changed
+- **`products +set-price` redesigned** — target by `--variant-id` (exact) or `--sku`; a SKU that matches multiple variants is refused with the candidates listed, `--all` updates every matching variant, and giving both cross-checks that they agree. The old `--product-id` was removed. Prevents the previous silent mass price update.
+- `app config link` writes the template default scopes (`read_customer write_cart_transform`) when neither the Dashboard nor the config supplies any (matching `app init`).
+- Removed the redundant `products collections +create` shortcut — the generated `products collections create` already accepts `product_ids` inline.
+
+### Fixed
+- **`products +search` / `+count` filters** — `--published` sends the correct `published`/`unpublished`/`any` enum (`true`/`false` accepted as aliases, invalid values error); `+search --vendor` uses the correct `vendors` param; removed flags the endpoints don't support (`+search --tags`, `+count --vendor`), which were previously ignored silently.
+
+### Notes
+- `products +stock`: verified against staging that the inventory API only adds and cannot reduce stock, so `--set` correctly refuses a decrease. Behavior unchanged.
+
+## 2.0.2 - 2026-06-18
+
+### Added
+- **Automatic update check** — the CLI checks npm for a newer version in the background and notes it on stderr; `shoplazza update` now checks first, shows live progress, and reports the before/after version. Skipped in CI.
+- Version output now includes the build date.
+
+### Changed
+- Checkout build toolchain: replaced the deprecated `jscodeshift` dependency with `acorn` + `magic-string` in the HTML-inline step (smaller install, fewer transitive deps); bundle output verified unchanged via golden tests.
+
+### Fixed
+- `auth status` always shows `granted_scopes` (`[]` when empty) instead of omitting the field.
+- `discounts +rebate` rejects combining `--target order` with product-scope flags locally, with a clear error instead of an opaque server 422.
+- Shortcut commands reject stray positional args (catching space-separated-instead-of-comma mistakes) with a helpful hint.
+
+## 2.0.1 - 2026-06-12
+
+Maintenance release (packaging); no functional changes.
+
 ## 2.0.0 - 2026-06-12
 
 First public release of the v2 CLI — a full rewrite in Go (the previous v1 was JavaScript).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Changelog
 
-## [Unreleased]
+## 2.0.4 - 2026-07-03
 
 ### Added
 - **`app deploy` v1 extension compatibility** — recognizes legacy `extension.config.json` extensions, handles the nested `theme-app/` theme layout, warns when an extension's config names a different app than the deploy target, and migrates v1 configs to `shoplazza.extension.toml` on deploy (marking the old JSON deprecated rather than deleting it).
 - `app config link` now auto-activates the linked config — no separate `app config use` step needed.
+- Analytics endpoints gain a `filter_crawler_type` param to exclude known bot/crawler traffic from statistics (`no_filter_crawler` default / `official_crawler`).
 
 ### Changed
 - `theme-extension connect` no longer needs `--partner`: it derives the app's partner from `--client-id` (consistent with `theme-extension release` and `app config link`). The `--partner` flag was removed.
 - `auth status` / `auth login` always include `current_store` (empty `""` when no store is selected), consistent with `granted_scopes`.
+- Clearer analytics param descriptions — `begin_time`/`end_time` spell out the string Unix-timestamp format, and the `filter`/`filters` params document their operator/value rules and supported keys.
 
 ### Fixed
 - `auth login --store-domain` now validates the store at login: an invalid or inaccessible store yields a clear warning and is not set as the current store, instead of surfacing later as a confusing `404 store_not_found`. Login itself still succeeds.

--- a/cmd/app/common.go
+++ b/cmd/app/common.go
@@ -25,6 +25,19 @@ func warnWriter(f *cmdutil.Factory) io.Writer {
 	return os.Stderr
 }
 
+// reconcileExtensionApps warns and drops the extension id when a v1 config's
+// owning app (AppID) differs from the deploy target, so it's created fresh.
+func reconcileExtensionApps(w io.Writer, locals []app.LocalExt, activeClientID string) []app.LocalExt {
+	for i := range locals {
+		if locals[i].AppID != "" && locals[i].AppID != activeClientID {
+			fmt.Fprintf(w, "warning: extension %q was created under app %s; deploying to %s creates it as a NEW extension here (its old id is ignored)\n",
+				locals[i].Name, locals[i].AppID, activeClientID)
+			locals[i].ExtensionID = ""
+		}
+	}
+	return locals
+}
+
 // requireLogin is the light app gate: only verifies "logged in (has UAT)".
 // It does NOT require a current store (unlike cmdutil.RequireAuth).
 func requireLogin(ctx context.Context, f *cmdutil.Factory) error {

--- a/cmd/app/common_test.go
+++ b/cmd/app/common_test.go
@@ -450,3 +450,35 @@ func TestEnsurePartnerID(t *testing.T) {
 		t.Fatalf("unresolvable partner: ex=%v (want validation error)", ex)
 	}
 }
+
+func TestReconcileExtensionApps(t *testing.T) {
+	// Mismatch: warns and drops the cross-app id so it deploys as new.
+	var buf bytes.Buffer
+	got := reconcileExtensionApps(&buf, []app.LocalExt{
+		{Name: "preorder", Type: "theme", ExtensionID: "657", AppID: "app_ff"},
+	}, "app_xuxu")
+	if got[0].ExtensionID != "" {
+		t.Errorf("cross-app id should be dropped, got %q", got[0].ExtensionID)
+	}
+	if !strings.Contains(buf.String(), "preorder") || !strings.Contains(buf.String(), "app_ff") {
+		t.Errorf("expected a cross-app warning naming the extension and its app, got %q", buf.String())
+	}
+
+	// Same app: keep the id, no warning.
+	buf.Reset()
+	got = reconcileExtensionApps(&buf, []app.LocalExt{
+		{Name: "co", ExtensionID: "777", AppID: "app_xuxu"},
+	}, "app_xuxu")
+	if got[0].ExtensionID != "777" || buf.Len() != 0 {
+		t.Errorf("same-app should keep id and not warn; id=%q warn=%q", got[0].ExtensionID, buf.String())
+	}
+
+	// v2 toml (no AppID): unchanged, no warning.
+	buf.Reset()
+	got = reconcileExtensionApps(&buf, []app.LocalExt{
+		{Name: "v2", ExtensionID: "999"},
+	}, "app_xuxu")
+	if got[0].ExtensionID != "999" || buf.Len() != 0 {
+		t.Errorf("v2 ext should be untouched; id=%q warn=%q", got[0].ExtensionID, buf.String())
+	}
+}

--- a/cmd/app/config.go
+++ b/cmd/app/config.go
@@ -109,7 +109,11 @@ func runConfigLink(ctx context.Context, d *app.Dashboard, p *project.Project, o 
 		}
 		return output.ErrInternal("failed to write %s: %v", configName, err)
 	}
-	return output.PrintBody(w, map[string]any{"config": configName, "client_id": ref.ClientID, "partner_id": ref.PartnerID}, format, jq)
+	// Linking implies "use this app now" — activate it (client_id already validated).
+	if err := p.SetActiveConfig(configName, ref.ClientID); err != nil {
+		return output.ErrInternal("failed to write app-state: %v", err)
+	}
+	return output.PrintBody(w, map[string]any{"config": configName, "active_config": configName, "client_id": ref.ClientID, "partner_id": ref.PartnerID}, format, jq)
 }
 
 // configFileForName maps a config name segment to its toml filename

--- a/cmd/app/config_test.go
+++ b/cmd/app/config_test.go
@@ -111,6 +111,13 @@ func TestRunConfigLink_LinkExisting(t *testing.T) {
 	if cfg.PartnerID != "p1" {
 		t.Fatalf("partner_id not persisted into config: got %q, want p1", cfg.PartnerID)
 	}
+	// link auto-activates the linked config.
+	if active, _ := p.ActiveConfigName(); active != "shoplazza.app.prod.toml" {
+		t.Fatalf("link should activate the config, got active=%q", active)
+	}
+	if !strings.Contains(buf.String(), "active_config") {
+		t.Fatalf("output should report active_config, got %s", buf.String())
+	}
 }
 
 func TestRunConfigLink_CreateNew(t *testing.T) {
@@ -136,6 +143,9 @@ func TestRunConfigLink_CreateNew(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(root, "shoplazza.app.dev.toml")); statErr != nil {
 		t.Fatalf("config file not written: %v", statErr)
+	}
+	if active, _ := p.ActiveConfigName(); active != "shoplazza.app.dev.toml" {
+		t.Fatalf("create+link should activate the config, got active=%q", active)
 	}
 }
 

--- a/cmd/app/deploy.go
+++ b/cmd/app/deploy.go
@@ -78,6 +78,9 @@ func newCmdDeploy(f *cmdutil.Factory) *cobra.Command {
 			if scanErr != nil {
 				return scanErr
 			}
+			// v1-compat: warn + drop ids for extensions whose legacy config names a
+			// different app than the one being deployed to.
+			locals = reconcileExtensionApps(warnWriter(f), locals, cid)
 
 			res, ex := app.Deploy(ctx, app.DeployDeps{
 				Dashboard:   d,

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -110,6 +110,9 @@ func newCmdLogin(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			fmt.Fprintf(f.IOStreams.ErrOut, "\nOK: Login successful!\n")
+			if result.StoreWarning != "" {
+				fmt.Fprintf(f.IOStreams.ErrOut, "  warning: %s\n", result.StoreWarning)
+			}
 			if result.Status.CurrentStore != "" {
 				fmt.Fprintf(f.IOStreams.ErrOut, "  Current store: %s\n", result.Status.CurrentStore)
 			}
@@ -118,13 +121,17 @@ func newCmdLogin(f *cmdutil.Factory) *cobra.Command {
 			}
 			fmt.Fprintf(f.IOStreams.ErrOut, "  UAT: %s\n", result.UAT)
 
-			return output.PrintJSON(cmd.OutOrStdout(), map[string]any{
+			out := map[string]any{
 				"ok":     true,
 				"action": "login",
 				"flow":   result.Flow,
 				"uat":    result.UAT,
 				"status": result.Status,
-			})
+			}
+			if result.StoreWarning != "" {
+				out["store_warning"] = result.StoreWarning
+			}
+			return output.PrintJSON(cmd.OutOrStdout(), out)
 		},
 	}
 

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -121,17 +121,14 @@ func newCmdLogin(f *cmdutil.Factory) *cobra.Command {
 			}
 			fmt.Fprintf(f.IOStreams.ErrOut, "  UAT: %s\n", result.UAT)
 
-			out := map[string]any{
+			// Store warning is shown in the stderr summary only, not echoed in the JSON.
+			return output.PrintJSON(cmd.OutOrStdout(), map[string]any{
 				"ok":     true,
 				"action": "login",
 				"flow":   result.Flow,
 				"uat":    result.UAT,
 				"status": result.Status,
-			}
-			if result.StoreWarning != "" {
-				out["store_warning"] = result.StoreWarning
-			}
-			return output.PrintJSON(cmd.OutOrStdout(), out)
+			})
 		},
 	}
 

--- a/cmd/theme_extension/common.go
+++ b/cmd/theme_extension/common.go
@@ -166,29 +166,6 @@ func partnerOpenapiClient(ctx context.Context, f *cmdutil.Factory, clientID, cli
 	return c, nil
 }
 
-// selectPartner — copy of cmd/app's (private there): flag wins; single
-// auto-selects; multiple without a flag is a validation error.
-func selectPartner(partners []app.Partner, flag string) (string, error) {
-	if flag != "" {
-		for _, p := range partners {
-			if string(p.ID) == flag {
-				return flag, nil
-			}
-		}
-		return "", output.ErrWithHint(output.ExitValidation, output.TypeValidation,
-			"partner '"+flag+"' not found in your account", "run 'shoplazza app list' to see partners")
-	}
-	switch len(partners) {
-	case 0:
-		return "", output.ErrValidation("no partners available for this account")
-	case 1:
-		return string(partners[0].ID), nil
-	default:
-		return "", output.ErrWithHint(output.ExitValidation, output.TypeValidation,
-			"multiple partners — specify which one", "pass --partner <partner_id> or run 'shoplazza app list'")
-	}
-}
-
 // apiError maps a client error to the right envelope: HTTP → api (naming the
 // failing endpoint; 403→auth inside ErrAPI); transport-level net.Error →
 // network; else internal. Mirrors cmd/app's apiError.

--- a/cmd/theme_extension/common_test.go
+++ b/cmd/theme_extension/common_test.go
@@ -3,14 +3,12 @@ package theme_extension
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"net"
 	"net/url"
 	"strings"
 	"testing"
 
-	"shoplazza-cli-v2/internal/app"
 	"shoplazza-cli-v2/internal/client"
 	"shoplazza-cli-v2/internal/cmdutil"
 	"shoplazza-cli-v2/internal/core"
@@ -73,56 +71,6 @@ func TestReleaseRequiresConnectFirst(t *testing.T) {
 	var ee *output.ExitError
 	if !errors.As(err, &ee) || ee.Detail == nil || ee.Detail.Type != output.TypeValidation {
 		t.Fatalf("expected validation (connect first), got %v", err)
-	}
-}
-
-// ── selectPartner ─────────────────────────────────────────────────────────────
-
-func mustParsePartners(t *testing.T, raw string) []app.Partner {
-	t.Helper()
-	var p []app.Partner
-	if err := json.Unmarshal([]byte(raw), &p); err != nil {
-		t.Fatalf("parse partners: %v", err)
-	}
-	return p
-}
-
-func TestSelectPartner_FlagMatchesPartner(t *testing.T) {
-	partners := mustParsePartners(t, `[{"id":"p1"},{"id":"p2"}]`)
-	got, err := selectPartner(partners, "p1")
-	if err != nil || got != "p1" {
-		t.Errorf("got (%q, %v) want (p1, nil)", got, err)
-	}
-}
-
-func TestSelectPartner_FlagNotFound(t *testing.T) {
-	partners := mustParsePartners(t, `[{"id":"p1"}]`)
-	_, err := selectPartner(partners, "unknown")
-	if err == nil {
-		t.Error("expected error when flag partner not found")
-	}
-}
-
-func TestSelectPartner_NoPartners(t *testing.T) {
-	_, err := selectPartner(nil, "")
-	if err == nil {
-		t.Error("expected error when no partners available")
-	}
-}
-
-func TestSelectPartner_SingleAutoSelected(t *testing.T) {
-	partners := mustParsePartners(t, `[{"id":"only-one"}]`)
-	got, err := selectPartner(partners, "")
-	if err != nil || got != "only-one" {
-		t.Errorf("single partner auto-select: got (%q, %v) want (only-one, nil)", got, err)
-	}
-}
-
-func TestSelectPartner_MultipleWithoutFlag(t *testing.T) {
-	partners := mustParsePartners(t, `[{"id":"p1"},{"id":"p2"}]`)
-	_, err := selectPartner(partners, "")
-	if err == nil {
-		t.Error("expected error when multiple partners and no flag")
 	}
 }
 

--- a/cmd/theme_extension/connect.go
+++ b/cmd/theme_extension/connect.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newCmdConnect(f *cmdutil.Factory) *cobra.Command {
-	var clientID, partner, path string
+	var clientID, path string
 	var cfg te.Config // validated by PreRunE; RunE reuses it (no lossy re-read)
 	cmd := &cobra.Command{
 		Use:   "connect",
@@ -32,13 +32,15 @@ func newCmdConnect(f *cmdutil.Factory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			partners, err := d.GetPartners(ctx)
+			// client_id uniquely identifies the app; derive its partner via /info
+			// (same as te release / app config link) — no --partner needed.
+			info, err := d.GetCompleteInfo(ctx, clientID)
 			if err != nil {
 				return apiError(err)
 			}
-			pid, err := selectPartner(partners.Partners, partner)
-			if err != nil {
-				return err
+			pid := string(info.Partner.ID)
+			if pid == "" {
+				return output.ErrInternal("could not resolve the app's partner from client_id %s", clientID)
 			}
 			appCfg, err := d.GetAppConfig(ctx, pid, clientID) // yields client_secret (not persisted) + partner_id
 			if err != nil {
@@ -54,9 +56,8 @@ func newCmdConnect(f *cmdutil.Factory) *cobra.Command {
 			if cErr := app.ConnectTheme(ctx, pc, cfg.Name, cfg.ExtensionID, app.ThemeConnectionPathStandalone); cErr != nil {
 				return cErr
 			}
-			// Persist the binding (client_id + its validated partner) so release
-			// knows the app AND can skip the partner lookup entirely. pid was
-			// validated above (selectPartner + GetAppConfig under that partner).
+			// Persist the binding (client_id + its partner) so release knows the app
+			// and can skip the partner lookup.
 			cfg.ClientID = clientID
 			cfg.PartnerID = pid
 			if wErr := te.WriteConfig(path, cfg); wErr != nil {
@@ -66,7 +67,6 @@ func newCmdConnect(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&clientID, "client-id", "", "App client_id to link (required)")
-	cmd.Flags().StringVar(&partner, "partner", "", "Partner id (auto-selected if you have only one)")
 	cmd.Flags().StringVar(&path, "path", ".", "te project root")
 	return cmd
 }

--- a/internal/app/build.go
+++ b/internal/app/build.go
@@ -154,6 +154,11 @@ func BuildArtifactFor(ctx context.Context, projectRoot string, l LocalExt, debug
 		return buildCheckout(ctx, projectRoot, l.Dir, debug)
 	case "theme":
 		src := filepath.Join(projectRoot, "extensions", l.Dir)
+		// v1 nests theme content under theme-app/; zip that subdir so the archive
+		// isn't double-nested (theme-app/theme-app/...). v2 (flat) has no such subdir.
+		if sub := filepath.Join(src, "theme-app"); isDir(sub) {
+			src = sub
+		}
 		// Content/time-unique name (v1 parity) — a static name collides with the
 		// overwrite-forbidden OSS object and silently reuses a stale artifact.
 		zipName, nErr := themeZipName(src, l.Name)
@@ -178,6 +183,12 @@ func BuildArtifactFor(ctx context.Context, projectRoot string, l LocalExt, debug
 	default:
 		return "", output.ErrValidation("unknown extension type %q in %s", l.Type, l.Dir)
 	}
+}
+
+// isDir reports whether path exists and is a directory.
+func isDir(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.IsDir()
 }
 
 // functionEntryPath returns the JS entry for a function extension:

--- a/internal/app/build_test.go
+++ b/internal/app/build_test.go
@@ -88,6 +88,46 @@ func TestThemeZipName_Deterministic_SameContent(t *testing.T) {
 	}
 }
 
+// TestBuildArtifactFor_Theme_V1NestedLayout: a v1 extension nests the theme
+// content under theme-app/ (alongside extension.config.json). The zip must root
+// the CONTENT at theme-app/ (so the backend finds theme-app/assets-manifest.json),
+// not double-nest it (theme-app/theme-app/...) or include the v1 metadata.
+func TestBuildArtifactFor_Theme_V1NestedLayout(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "preorder")
+	themeApp := filepath.Join(extDir, "theme-app")
+	os.MkdirAll(filepath.Join(themeApp, "blocks"), 0o755)
+	os.WriteFile(filepath.Join(themeApp, "assets-manifest.json"), []byte("{}"), 0o644)
+	os.WriteFile(filepath.Join(themeApp, "blocks", "a.liquid"), []byte("x"), 0o644)
+	// v1 metadata at the extension root — must NOT end up in the theme bundle.
+	os.WriteFile(filepath.Join(extDir, "extension.config.json"), []byte("{}"), 0o644)
+
+	got, exitErr := BuildArtifactFor(context.Background(), root, LocalExt{
+		Dir: "preorder", Name: "preorder", Type: "theme",
+	}, false)
+	if exitErr != nil {
+		t.Fatalf("BuildArtifactFor: %v", exitErr)
+	}
+	zr, err := zip.OpenReader(got)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer zr.Close()
+	found := map[string]bool{}
+	for _, f := range zr.File {
+		found[f.Name] = true
+	}
+	if !found["theme-app/assets-manifest.json"] || !found["theme-app/blocks/a.liquid"] {
+		t.Fatalf("content must be rooted at theme-app/: %v", found)
+	}
+	if found["theme-app/theme-app/assets-manifest.json"] {
+		t.Fatalf("must not double-nest theme-app/: %v", found)
+	}
+	if found["theme-app/extension.config.json"] {
+		t.Fatalf("v1 metadata must not be bundled: %v", found)
+	}
+}
+
 func TestBuildArtifactFor_UnknownType_Errors(t *testing.T) {
 	_, exitErr := BuildArtifactFor(context.Background(), t.TempDir(), LocalExt{
 		Dir: "myext", Name: "myext", Type: "unknown-type",

--- a/internal/app/deploy.go
+++ b/internal/app/deploy.go
@@ -284,9 +284,16 @@ func buildUploadUpsert(ctx context.Context, deps DeployDeps) ([]DeployedExt, str
 		// Persist the server-issued id into the extension toml so the NEXT
 		// dev/deploy id-matches instead of re-creating (v1 deploy.js:156 /
 		// dev.js:154). Only on change — the common update path stays write-free.
-		if got := deployed[len(deployed)-1].ExtensionID; got != "" && got != p.Local.ExtensionID && deps.ProjectRoot != "" {
-			if wErr := WriteBackExtensionVersion(deps.ProjectRoot, p.Local.Dir, got, ""); wErr != nil {
-				return nil, "", wrapExtErr(p.Local, output.ErrInternal("upsert succeeded but writing back extension id failed: %v", wErr))
+		if got := deployed[len(deployed)-1].ExtensionID; got != "" && deps.ProjectRoot != "" {
+			if got != p.Local.ExtensionID {
+				if wErr := WriteBackExtensionVersion(deps.ProjectRoot, p.Local.Dir, got, ""); wErr != nil {
+					return nil, "", wrapExtErr(p.Local, output.ErrInternal("upsert succeeded but writing back extension id failed: %v", wErr))
+				}
+			}
+			// v1-compat: migrate a legacy extension.config.json to a v2 toml. No-op otherwise.
+			ext := deployed[len(deployed)-1]
+			if mErr := MigrateV1Extension(deps.ProjectRoot, p.Local.Dir, got, ext.Name, ext.Type, ext.Version); mErr != nil {
+				return nil, "", wrapExtErr(p.Local, output.ErrInternal("upsert succeeded but migrating v1 config failed: %v", mErr))
 			}
 		}
 	}

--- a/internal/app/diff.go
+++ b/internal/app/diff.go
@@ -15,6 +15,7 @@ type LocalExt struct {
 	Type        string
 	Version     string // optional; from the extension toml. Diff ignores it.
 	ExtensionID string // optional; set once known
+	AppID       string // v1 extension.config.json `appId`; empty for v2. Diff ignores it.
 }
 
 // Pair maps a local extension to its remote counterpart. Remote is nil when the

--- a/internal/app/scan.go
+++ b/internal/app/scan.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -17,6 +18,16 @@ type scanExtToml struct {
 	Name    string `toml:"name"`
 	Type    string `toml:"type"`
 	Version string `toml:"version"`
+}
+
+// v1ExtConfig is the subset of the legacy v1 extension.config.json the scanner
+// reads as a fallback when no v2 toml is present.
+type v1ExtConfig struct {
+	ExtensionID   string `json:"extensionId"`
+	AppID         string `json:"appId"`
+	ExtensionName string `json:"extensionName"`
+	Version       string `json:"version"`
+	Type          string `json:"type"`
 }
 
 // ScanLocalExtensions reads <root>/extensions/*/shoplazza.extension.toml and
@@ -40,21 +51,51 @@ func ScanLocalExtensions(root string) ([]LocalExt, *output.ExitError) {
 			continue
 		}
 		var et scanExtToml
-		if _, err := toml.DecodeFile(filepath.Join(dir, e.Name(), "shoplazza.extension.toml"), &et); err != nil {
-			// toml.DecodeFile on a missing file returns a *fs.PathError that
-			// satisfies os.ErrNotExist — that's a non-extension dir, skip it.
-			if errors.Is(err, os.ErrNotExist) {
-				continue
-			}
+		_, err := toml.DecodeFile(filepath.Join(dir, e.Name(), "shoplazza.extension.toml"), &et)
+		if err == nil {
+			out = append(out, LocalExt{
+				Dir:         e.Name(),
+				Name:        et.Name,
+				Type:        et.Type,
+				Version:     et.Version,
+				ExtensionID: et.ID,
+			})
+			continue
+		}
+		if !errors.Is(err, os.ErrNotExist) {
 			return nil, output.ErrValidation("extensions/%s/shoplazza.extension.toml is malformed: %v", e.Name(), err)
+		}
+
+		// No v2 toml — fall back to the legacy v1 extension.config.json.
+		v1, vErr := readV1ExtConfig(filepath.Join(dir, e.Name(), "extension.config.json"))
+		if vErr != nil {
+			if errors.Is(vErr, os.ErrNotExist) {
+				continue // neither v2 nor v1: not an extension dir, skip
+			}
+			return nil, output.ErrValidation("extensions/%s/extension.config.json is malformed: %v", e.Name(), vErr)
 		}
 		out = append(out, LocalExt{
 			Dir:         e.Name(),
-			Name:        et.Name,
-			Type:        et.Type,
-			Version:     et.Version,
-			ExtensionID: et.ID,
+			Name:        v1.ExtensionName,
+			Type:        v1.Type,
+			Version:     v1.Version,
+			ExtensionID: v1.ExtensionID,
+			AppID:       v1.AppID,
 		})
 	}
 	return out, nil
+}
+
+// readV1ExtConfig reads a legacy v1 extension.config.json. A missing file
+// returns an error satisfying os.ErrNotExist (so the caller can skip).
+func readV1ExtConfig(path string) (v1ExtConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return v1ExtConfig{}, err
+	}
+	var c v1ExtConfig
+	if err := json.Unmarshal(data, &c); err != nil {
+		return v1ExtConfig{}, err
+	}
+	return c, nil
 }

--- a/internal/app/scan_test.go
+++ b/internal/app/scan_test.go
@@ -66,6 +66,77 @@ func TestScanLocalExtensions_DirWithoutToml_Skipped(t *testing.T) {
 	}
 }
 
+// TestScanLocalExtensions_V1Fallback: a dir with only the legacy v1
+// extension.config.json (no v2 toml) is read and mapped to LocalExt, so v1
+// projects deploy without a manual migration.
+func TestScanLocalExtensions_V1Fallback(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "preorder")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v1 := `{"extensionId":"657218221862028613","appId":"app_x","partnerId":"3665","extensionName":"preorder","version":"1.0.0","type":"theme","subtype":"basic"}`
+	if err := os.WriteFile(filepath.Join(extDir, "extension.config.json"), []byte(v1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	locals, err := ScanLocalExtensions(root)
+	if err != nil {
+		t.Fatalf("ScanLocalExtensions: %v", err)
+	}
+	if len(locals) != 1 {
+		t.Fatalf("locals = %+v, want 1", locals)
+	}
+	got := locals[0]
+	if got.ExtensionID != "657218221862028613" || got.Name != "preorder" || got.Type != "theme" || got.Version != "1.0.0" || got.AppID != "app_x" {
+		t.Fatalf("v1 mapping wrong: %+v", got)
+	}
+}
+
+// TestScanLocalExtensions_V2TomlWinsOverV1: when both formats are present, the
+// v2 toml is authoritative and the v1 json is ignored.
+func TestScanLocalExtensions_V2TomlWinsOverV1(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "co")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "shoplazza.extension.toml"),
+		[]byte("id = \"v2id\"\nname = \"co\"\ntype = \"checkout\"\nversion = \"2.0.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "extension.config.json"),
+		[]byte(`{"extensionId":"v1id","extensionName":"co","type":"checkout","version":"1.0.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	locals, err := ScanLocalExtensions(root)
+	if err != nil {
+		t.Fatalf("ScanLocalExtensions: %v", err)
+	}
+	if len(locals) != 1 || locals[0].ExtensionID != "v2id" || locals[0].AppID != "" {
+		t.Fatalf("toml should win: %+v", locals)
+	}
+}
+
+// TestScanLocalExtensions_V1Malformed_Validation: a present but unparseable v1
+// json surfaces as a validation error naming the file, like the toml path.
+func TestScanLocalExtensions_V1Malformed_Validation(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "bad")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(extDir, "extension.config.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ScanLocalExtensions(root)
+	if err == nil {
+		t.Fatal("expected validation error for malformed v1 config")
+	}
+	if err.Code != output.ExitValidation || !strings.Contains(err.Error(), "extensions/bad/extension.config.json") {
+		t.Fatalf("error should name the v1 file as validation, got %q (code %d)", err.Error(), err.Code)
+	}
+}
+
 // TestScanLocalExtensions_MalformedToml_Validation: a present but
 // unparseable extension toml must surface as a validation error naming the
 // file — silently skipping it made deploy/dev quietly ignore the extension.

--- a/internal/app/writeback.go
+++ b/internal/app/writeback.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -42,4 +43,66 @@ func WriteBackExtensionVersion(root, dir, id, version string) error {
 		return err
 	}
 	return fsx.WriteFileAtomic(path, buf.Bytes(), 0o644)
+}
+
+// deprecationNotice marks a migrated v1 extension.config.json (JSON has no comments).
+const deprecationNotice = "DEPRECATED: superseded by shoplazza.extension.toml (v2). The CLI no longer reads this file."
+
+// MigrateV1Extension writes a v2 shoplazza.extension.toml (with the deployed id)
+// for a legacy extension.config.json and marks the json deprecated (kept, not
+// deleted). appId/partnerId are not carried over. No-op when there's no v1 json.
+func MigrateV1Extension(root, dir, id, name, typ, version string) error {
+	extDir := filepath.Join(root, project.ExtensionsDir, dir)
+	jsonPath := filepath.Join(extDir, "extension.config.json")
+	if _, err := os.Stat(jsonPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // no v1 json → nothing to migrate
+		}
+		return err
+	}
+
+	// Write the v2 toml unless one already exists (then the write-back owns it).
+	tomlPath := filepath.Join(extDir, "shoplazza.extension.toml")
+	if _, err := os.Stat(tomlPath); errors.Is(err, os.ErrNotExist) {
+		m := map[string]any{"name": name, "type": typ}
+		if id != "" {
+			m["id"] = id
+		}
+		if version != "" {
+			m["version"] = version
+		}
+		var buf bytes.Buffer
+		if err := toml.NewEncoder(&buf).Encode(m); err != nil {
+			return err
+		}
+		if err := fsx.WriteFileAtomic(tomlPath, buf.Bytes(), 0o644); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return deprecateV1Config(jsonPath)
+}
+
+// deprecateV1Config adds a `_deprecated` notice to the v1 json, preserving its
+// other keys. Idempotent: an already-marked file is left untouched.
+func deprecateV1Config(jsonPath string) error {
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		return err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	if _, ok := m["_deprecated"]; ok {
+		return nil
+	}
+	m["_deprecated"] = deprecationNotice
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return fsx.WriteFileAtomic(jsonPath, append(out, '\n'), 0o644)
 }

--- a/internal/app/writeback_test.go
+++ b/internal/app/writeback_test.go
@@ -1,0 +1,127 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestMigrateV1Extension_WritesTomlAndDeprecatesJSON(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "preorder")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jsonPath := filepath.Join(extDir, "extension.config.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"extensionId":"old","appId":"ff","partnerId":"3665"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigrateV1Extension(root, "preorder", "newid", "preorder", "theme", "1.0.0"); err != nil {
+		t.Fatalf("MigrateV1Extension: %v", err)
+	}
+
+	// v1 json is KEPT, with a _deprecated notice added and original keys intact.
+	jb, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("json should be kept: %v", err)
+	}
+	var jm map[string]any
+	if err := json.Unmarshal(jb, &jm); err != nil {
+		t.Fatalf("json should stay valid: %v", err)
+	}
+	if _, ok := jm["_deprecated"]; !ok {
+		t.Errorf("json should gain a _deprecated marker, got %v", jm)
+	}
+	if jm["extensionId"] != "old" {
+		t.Errorf("original json keys must be preserved, got %v", jm)
+	}
+	// v2 toml written with the NEW id and name/type; no appId/partnerId.
+	var m map[string]any
+	if _, err := toml.DecodeFile(filepath.Join(extDir, "shoplazza.extension.toml"), &m); err != nil {
+		t.Fatalf("decode toml: %v", err)
+	}
+	if m["id"] != "newid" || m["name"] != "preorder" || m["type"] != "theme" {
+		t.Errorf("toml = %v, want id=newid name=preorder type=theme", m)
+	}
+	if _, ok := m["appId"]; ok {
+		t.Errorf("v2 toml must not carry appId: %v", m)
+	}
+	if _, ok := m["partnerId"]; ok {
+		t.Errorf("v2 toml must not carry partnerId: %v", m)
+	}
+}
+
+func TestMigrateV1Extension_Idempotent(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "preorder")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jsonPath := filepath.Join(extDir, "extension.config.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"extensionId":"old"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateV1Extension(root, "preorder", "newid", "preorder", "theme", "1.0.0"); err != nil {
+		t.Fatal(err)
+	}
+	first, _ := os.ReadFile(jsonPath)
+	if err := MigrateV1Extension(root, "preorder", "newid", "preorder", "theme", "1.0.0"); err != nil {
+		t.Fatal(err)
+	}
+	second, _ := os.ReadFile(jsonPath)
+	if string(first) != string(second) {
+		t.Errorf("re-migration should not rewrite an already-deprecated json")
+	}
+}
+
+func TestMigrateV1Extension_NoJSON_NoOp(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "v2only")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateV1Extension(root, "v2only", "id", "v2only", "theme", ""); err != nil {
+		t.Fatalf("MigrateV1Extension: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(extDir, "shoplazza.extension.toml")); !os.IsNotExist(err) {
+		t.Errorf("no v1 json → must not create a toml; stat err=%v", err)
+	}
+}
+
+func TestMigrateV1Extension_TomlExists_KeepsTomlMarksJSON(t *testing.T) {
+	root := t.TempDir()
+	extDir := filepath.Join(root, "extensions", "both")
+	if err := os.MkdirAll(extDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jsonPath := filepath.Join(extDir, "extension.config.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"extensionId":"old"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tomlPath := filepath.Join(extDir, "shoplazza.extension.toml")
+	if err := os.WriteFile(tomlPath, []byte("id=\"keep\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateV1Extension(root, "both", "newid", "both", "theme", ""); err != nil {
+		t.Fatalf("MigrateV1Extension: %v", err)
+	}
+	// toml present → write-back owns it, so it's not overwritten here.
+	var m map[string]any
+	if _, err := toml.DecodeFile(tomlPath, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["id"] != "keep" {
+		t.Errorf("existing toml must not be overwritten, got id=%v", m["id"])
+	}
+	// json still gets the deprecation marker.
+	jb, _ := os.ReadFile(jsonPath)
+	var jm map[string]any
+	_ = json.Unmarshal(jb, &jm)
+	if _, ok := jm["_deprecated"]; !ok {
+		t.Errorf("json should be marked deprecated even when a toml already exists: %v", jm)
+	}
+}

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -71,14 +71,35 @@ func (m *Manager) Login(ctx context.Context, storeDomain string, scopes []string
 			continue
 		case "ok":
 			state := stateFromPoll(pollRes, storeDomain)
+			warning := ""
+			// Validate the requested store now (post-consent) unless the session
+			// pre-warmed its token; a bad store is reported, not set as current.
+			if storeDomain != "" && pollRes.StoreToken == nil {
+				if block, sErr := m.exchangeStoreAT(ctx, pollRes.UAT, storeDomain); sErr != nil {
+					state.CurrentStore = ""
+					warning = storeValidationWarning(storeDomain, sErr)
+				} else {
+					applyStoreToken(&state, block, storeDomain)
+				}
+			}
 			if err := m.persistState(state); err != nil {
 				return LoginResult{Flow: "web", AuthorizeURL: session.AuthorizeURL}, err
 			}
-			return LoginResult{Flow: "web", UAT: pollRes.UAT, AuthorizeURL: session.AuthorizeURL, Status: statusFromState(state)}, nil
+			return LoginResult{Flow: "web", UAT: pollRes.UAT, AuthorizeURL: session.AuthorizeURL, Status: statusFromState(state), StoreWarning: warning}, nil
 		default:
 			return LoginResult{Flow: "web", AuthorizeURL: session.AuthorizeURL}, errors.New("unexpected session status: " + pollRes.Status)
 		}
 	}
+}
+
+// storeValidationWarning renders the login-time message for a store that failed
+// validation. A 404 means the domain doesn't exist or isn't accessible.
+func storeValidationWarning(domain string, err error) string {
+	var he *client.HTTPError
+	if errors.As(err, &he) && he.StatusCode == 404 {
+		return fmt.Sprintf("store %q not found or not accessible — not set as current store", domain)
+	}
+	return fmt.Sprintf("could not validate store %q (%v) — not set as current store", domain, err)
 }
 
 // applyStoreToken records a freshly minted store token in state, keyed by the

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -421,6 +421,9 @@ func TestCurrentStatus_GrantedScopesAlwaysPresent(t *testing.T) {
 	if !strings.Contains(string(b), `"granted_scopes":[]`) {
 		t.Errorf("granted_scopes must serialize as [] when empty (not null/omitted); got %s", b)
 	}
+	if !strings.Contains(string(b), `"current_store":""`) {
+		t.Errorf("current_store must serialize as \"\" when empty (not omitted); got %s", b)
+	}
 }
 
 // Regression: when the prewarmed store_token echoes a domain different from

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -37,9 +37,10 @@ func newTestManager(t *testing.T, srv *httptest.Server) *internalauth.Manager {
 }
 
 type brokerOpts struct {
-	pendingPolls int
-	okBody       map[string]any
-	storeAT      map[string]any
+	pendingPolls  int
+	okBody        map[string]any
+	storeAT       map[string]any
+	storeATStatus int // when non-zero and != 200, store-at responds with this status
 }
 
 // brokerServer mocks the auth backend for the interactive web flow: pending → ok,
@@ -62,6 +63,11 @@ func brokerServer(t *testing.T, opts brokerOpts) *httptest.Server {
 		case r.URL.Path == "/api/saiga/cli/auth/me":
 			json.NewEncoder(w).Encode(map[string]any{"user_id": "u1", "account": "alice@example.com"})
 		case r.URL.Path == "/api/saiga/cli/auth/exchange/store-at":
+			if opts.storeATStatus != 0 && opts.storeATStatus != http.StatusOK {
+				w.WriteHeader(opts.storeATStatus)
+				w.Write([]byte(`{"code":"store_not_found","errors":["store not found"]}`))
+				return
+			}
 			json.NewEncoder(w).Encode(opts.storeAT)
 		default:
 			t.Errorf("unexpected path: %s", r.URL.Path)
@@ -126,9 +132,12 @@ func TestLogin_WithStoreDomain_PrewarmsStoreToken(t *testing.T) {
 	}
 }
 
-func TestLogin_WithStoreDomain_PrewarmMissing_StillSetsCurrentStore(t *testing.T) {
+// When the session omits a prewarmed store_token, login validates the store via
+// an explicit store-at exchange; a valid store gets set + its token cached.
+func TestLogin_WithStoreDomain_PrewarmMissing_ValidatesViaExchange(t *testing.T) {
 	srv := brokerServer(t, brokerOpts{
-		okBody: map[string]any{"status": "ok", "uat": "uat_s", "account": "a@x.com"}, // no store_token
+		okBody:  map[string]any{"status": "ok", "uat": "uat_s", "account": "a@x.com"}, // no store_token
+		storeAT: map[string]any{"access_token": "at_validated", "store_id": "7", "store_domain": "my-store.com", "granted_scopes": []string{"read_product"}, "at_expires_at": "2099-01-01T00:00:00Z"},
 	})
 	defer srv.Close()
 	mgr := newTestManager(t, srv)
@@ -137,12 +146,41 @@ func TestLogin_WithStoreDomain_PrewarmMissing_StillSetsCurrentStore(t *testing.T
 	if err != nil {
 		t.Fatalf("Login: %v", err)
 	}
-	if res.Status.CurrentStore != "my-store.com" {
-		t.Errorf("current store should be set even when prewarm omits store_token; got %q", res.Status.CurrentStore)
+	if res.Status.CurrentStore != "my-store.com" || res.StoreWarning != "" {
+		t.Errorf("valid store should be set with no warning; current=%q warn=%q", res.Status.CurrentStore, res.StoreWarning)
 	}
 	st, _ := mgr.LoadState()
-	if _, ok := st.Stores["my-store.com"]; ok {
-		t.Errorf("no store token expected when prewarm omitted it")
+	if st.Stores["my-store.com"].Token != "at_validated" {
+		t.Errorf("validated store token should be cached, got %q", st.Stores["my-store.com"].Token)
+	}
+}
+
+// A bad/inaccessible --store-domain (store-at 404) does not fail login: it warns
+// and leaves the store unset, and the bad domain is never persisted.
+func TestLogin_WithStoreDomain_ValidationFails_WarnsAndUnsets(t *testing.T) {
+	srv := brokerServer(t, brokerOpts{
+		okBody:        map[string]any{"status": "ok", "uat": "uat_s", "account": "a@x.com"}, // no store_token
+		storeATStatus: http.StatusNotFound,
+	})
+	defer srv.Close()
+	mgr := newTestManager(t, srv)
+
+	res, err := mgr.Login(context.Background(), "bad-store.com", nil, "", 5*time.Second, time.Millisecond, nil)
+	if err != nil {
+		t.Fatalf("login should still succeed on a bad store: %v", err)
+	}
+	if res.Status.CurrentStore != "" {
+		t.Errorf("bad store must not be set as current, got %q", res.Status.CurrentStore)
+	}
+	if !strings.Contains(res.StoreWarning, "bad-store.com") {
+		t.Errorf("expected a store warning naming the domain, got %q", res.StoreWarning)
+	}
+	st, _ := mgr.LoadState()
+	if st.CurrentStore != "" || len(st.Stores) != 0 {
+		t.Errorf("bad store must not be persisted: current=%q stores=%v", st.CurrentStore, st.Stores)
+	}
+	if st.UAT != "uat_s" {
+		t.Errorf("login (UAT) should still persist, got %q", st.UAT)
 	}
 }
 

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -83,7 +83,7 @@ type Status struct {
 	LoggedIn      bool                   `json:"logged_in"`
 	Account       string                 `json:"account,omitempty"`
 	UserID        string                 `json:"user_id,omitempty"`
-	CurrentStore  string                 `json:"current_store,omitempty"`
+	CurrentStore  string                 `json:"current_store"` // always present ("" when no store), like granted_scopes
 	GrantedScopes []string               `json:"granted_scopes"`
 	UATAvailable  bool                   `json:"uat_available"`
 	UATExpiresAt  string                 `json:"uat_expires_at,omitempty"`

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -95,6 +95,9 @@ type LoginResult struct {
 	UAT          string
 	AuthorizeURL string // non-empty for web flow
 	Status       Status
+	// StoreWarning is set when a requested --store-domain fails validation at
+	// login; login still succeeds but the store is not set as current.
+	StoreWarning string
 }
 
 // ── HTTP request / response types ────────────────────────────────────────────

--- a/internal/registry/cli_meta_v202601_en.json
+++ b/internal/registry/cli_meta_v202601_en.json
@@ -1,6 +1,6 @@
 {
   "version": "v202601",
-  "generated_at": "2026-06-17T02:43:22Z",
+  "generated_at": "2026-07-03T02:40:28Z",
   "modules": [
     {
       "name": "billing",
@@ -6376,14 +6376,14 @@
                 "name": "begin_time",
                 "type": "string",
                 "required": true,
-                "description": "Start time as Unix timestamp in seconds.",
+                "description": "Start time, a Unix timestamp in seconds passed as a string, e.g. \"1748736000\".",
                 "min_length": 1
               },
               {
                 "name": "end_time",
                 "type": "string",
                 "required": true,
-                "description": "End time as Unix timestamp in seconds.",
+                "description": "End time, a Unix timestamp in seconds passed as a string, e.g. \"1781481600\". Should be greater than begin_time.",
                 "min_length": 1
               },
               {
@@ -6429,7 +6429,12 @@
               {
                 "name": "filters",
                 "type": "string",
-                "description": "JSON filter object, e.g. {\"land_url_path\": {\"operator\": \"like\", \"value\": \"/\"}}."
+                "description": "Advanced filter conditions as a JSON string, expressed as a nested filter tree: - Array node `[ ... ]`: its children are combined with OR. - Object node `{ ... }`: its entries are combined with AND. - Leaf node: {\"operator\": \"...\", \"value\": ...} attached under a filter key. The `value` type to send depends on the operator (operators are case-insensitive): - `in`, `not in`             -\u003e value is an ARRAY, e.g. [\"a\", \"b\"]. A scalar will NOT match, so always send an array for these operators. - `like`, `not like`         -\u003e value is a STRING, e.g. \"google\" - `=`, `\u003e`, `\u003e=`, `\u003c`, `\u003c=`  -\u003e value is a SCALAR (string or number), e.g. 10 value is auto-converted to the target field type. Common keys: `land_url_path`, `last_template_name` (page type), `last_referrer_show`. Unknown keys or unsupported operators are silently ignored, so a filter \"not taking effect\" usually means a mistyped key/operator. e.g. AND: {\"land_url_path\": {\"operator\": \"like\", \"value\": \"/\"}} OR : [{\"last_referrer_show\": {\"operator\": \"like\", \"value\": \"google\"}}, {\"last_referrer_show\": {\"operator\": \"like\", \"value\": \"facebook\"}}]"
+              },
+              {
+                "name": "filter_crawler_type",
+                "type": "string",
+                "description": "Crawler-filtering policy that controls whether bot/crawler traffic is excluded from the statistics. Values: - `no_filter_crawler`: do not filter; count all traffic (default). - `official_crawler`: exclude known crawlers/bots."
               }
             ]
           },
@@ -6456,14 +6461,14 @@
                 "name": "begin_time",
                 "type": "string",
                 "required": true,
-                "description": "Start time as Unix timestamp in seconds.",
+                "description": "Start time, a Unix timestamp in seconds passed as a string, e.g. \"1748736000\".",
                 "min_length": 1
               },
               {
                 "name": "end_time",
                 "type": "string",
                 "required": true,
-                "description": "End time as Unix timestamp in seconds.",
+                "description": "End time, a Unix timestamp in seconds passed as a string, e.g. \"1781481600\". Should be greater than begin_time.",
                 "min_length": 1
               },
               {
@@ -6570,6 +6575,11 @@
                 "name": "created_at_max_at",
                 "type": "string",
                 "description": "Maximum product creation time, e.g. \"2026-04-04 00:00:00\"."
+              },
+              {
+                "name": "filter_crawler_type",
+                "type": "string",
+                "description": "Crawler-filtering policy that controls whether bot/crawler traffic is excluded from the statistics. Values: - `no_filter_crawler`: do not filter; count all traffic (default). - `official_crawler`: exclude known crawlers/bots."
               }
             ]
           },
@@ -6602,14 +6612,14 @@
                 "name": "begin_time",
                 "type": "string",
                 "required": true,
-                "description": "The starting timestamp (in seconds) for retrieving analysis data. Must be a valid Unix timestamp and less than end_time. Typically set to the start of the day (00:00) in the relevant timezone.",
+                "description": "Start time for retrieving analysis data: a Unix timestamp in seconds, passed as a string (e.g. \"1748736000\"). Must be less than end_time; typically the start of the day (00:00) in the relevant timezone.",
                 "min_length": 1
               },
               {
                 "name": "end_time",
                 "type": "string",
                 "required": true,
-                "description": "The ending timestamp (in seconds) for retrieving analysis data. Must be a valid Unix timestamp and greater than begin_time. Typically set to the start of the following day (00:00) in the relevant timezone.",
+                "description": "End time for retrieving analysis data: a Unix timestamp in seconds, passed as a string (e.g. \"1781481600\"). Must be greater than begin_time; typically the start of the following day (00:00) in the relevant timezone.",
                 "min_length": 1
               },
               {
@@ -6660,12 +6670,17 @@
               {
                 "name": "filter",
                 "type": "string",
-                "description": "e.g. {\"spu\": {\"operator\": \"in\", \"value\": [\"spu1\"]}} Advanced filter conditions in JSON format. Only takes effect when search_model is \"advanced\"."
+                "description": "Advanced filter conditions as a JSON string. Only takes effect when `search_model` is \"advanced\". A flat JSON object that maps each filter key to a leaf {\"operator\": \"...\", \"value\": ...}; multiple keys are combined with AND (this endpoint does not support OR groups). The `value` type to send depends on the operator (operators are case-insensitive): - `in`, `not in`             -\u003e value is an ARRAY of strings, e.g. [\"SPU001\", \"SPU002\"] - `like`, `not like`         -\u003e value is a STRING, e.g. \"shirt\" - `=`, `\u003e`, `\u003e=`, `\u003c`, `\u003c=`  -\u003e value is a SCALAR (string or number), e.g. 10 Key -\u003e expected value: list keys (`spu`, `sku`, `product_id`, `title`, `tag_list`) use the array form; range keys (`price_min`/`price_max`, `cost_price_min`/`cost_price_max`, `compare_at_price_min`/`compare_at_price_max`, `created_at_min`/`created_at_max`, `updated_at_min`/`updated_at_max`) use a scalar; boolean keys (`published`, `sub_category`) use \"true\"/\"false\"; other keys (`collection_id`, `keyword`, `vendor`, `category`, `product_note`, `sales_platform`) use a string. Unknown keys are silently ignored (the request still returns 200), so a filter \"not taking effect\" usually means a mistyped key. e.g. {\"spu\": {\"operator\": \"in\", \"value\": [\"SPU001\", \"SPU002\"]}}"
               },
               {
                 "name": "with_impression",
                 "type": "boolean",
                 "description": "Whether to include impression data in the response."
+              },
+              {
+                "name": "filter_crawler_type",
+                "type": "string",
+                "description": "Crawler-filtering policy that controls whether bot/crawler traffic is excluded from the statistics. Values: - `no_filter_crawler`: do not filter; count all traffic (default). - `official_crawler`: exclude known crawlers/bots."
               }
             ]
           },
@@ -6692,14 +6707,14 @@
                 "name": "begin_time",
                 "type": "string",
                 "required": true,
-                "description": "Start time as Unix timestamp in seconds.",
+                "description": "Start time, a Unix timestamp in seconds passed as a string, e.g. \"1748736000\".",
                 "min_length": 1
               },
               {
                 "name": "end_time",
                 "type": "string",
                 "required": true,
-                "description": "End time as Unix timestamp in seconds.",
+                "description": "End time, a Unix timestamp in seconds passed as a string, e.g. \"1781481600\". Should be greater than begin_time.",
                 "min_length": 1
               },
               {
@@ -6744,7 +6759,12 @@
                   "type": "object",
                   "schema": "v202506.UTMFilter"
                 },
-                "description": "Optional filters to narrow results by UTM dimension values."
+                "description": "Optional list of structured filters to narrow results by UTM dimension values. Entries in the list are combined with AND. e.g. [{\"title\": \"utm_medium\", \"prerequisite\": \"includes\", \"values\": [\"123\"]}]"
+              },
+              {
+                "name": "filter_crawler_type",
+                "type": "string",
+                "description": "Crawler-filtering policy that controls whether bot/crawler traffic is excluded from the statistics. Values: - `no_filter_crawler`: do not filter; count all traffic (default). - `official_crawler`: exclude known crawlers/bots."
               }
             ]
           },
@@ -6771,14 +6791,14 @@
                 "name": "begin_time",
                 "type": "string",
                 "required": true,
-                "description": "Begin time.",
+                "description": "Start time, a Unix timestamp in seconds passed as a string, e.g. \"1748736000\".",
                 "min_length": 1
               },
               {
                 "name": "end_time",
                 "type": "string",
                 "required": true,
-                "description": "End time.",
+                "description": "End time, a Unix timestamp in seconds passed as a string, e.g. \"1781481600\". Should be greater than begin_time.",
                 "min_length": 1
               },
               {
@@ -6840,7 +6860,7 @@
                 "items": {
                   "type": "string"
                 },
-                "description": "Filters for analysis, such as UTM source or country code."
+                "description": "Simple equality filters, keyed by dimension name with the exact value to match, e.g. {\"country_code\": \"US\"}. Each entry is an exact-match condition and multiple entries are combined with AND. Only keys within the supported `dimension` set take effect; unknown keys are ignored."
               }
             ]
           },
@@ -11015,9 +11035,7 @@
         },
         {
           "name": "tracking_number",
-          "type": "string",
-          "required": true,
-          "min_length": 1
+          "type": "string"
         },
         {
           "name": "tracking_company",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shoplazza-cli",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "The official CLI for Shoplazza Open Platform",
   "bin": {
     "shoplazza": "scripts/run.js"

--- a/shortcuts/products/stock.go
+++ b/shortcuts/products/stock.go
@@ -16,9 +16,7 @@ import (
 //
 // --adjust N: direct PUT /inventory_levels with stock_adjustment=N (N must be > 0; the API rejects 0 and negatives).
 // --set N: client-side simulation — GET the current level, compute delta = N - current, then PUT, since the
-// /set endpoint behaves as add (not set). Decrement (N < current) is rejected because the API has no decrement primitive.
-// Verified 2026-06 against staging: POST /inventory_levels/set ADDS despite its "Set" name, and PUT /inventory_levels
-// rejects stock_adjustment ≤ 0 — so neither endpoint can reduce stock. Do not "fix" this by trusting the registry doc.
+// /set endpoint behaves as add (not set). Decrement (N < current) is rejected: the API has no decrement primitive.
 var stockShortcut = common.Shortcut{
 	Service: "products",
 	Command: "+stock",


### PR DESCRIPTION
Release **2.0.4**. Merges the current `develop` cycle into `main`.

## Added
- **`app deploy` v1 extension compatibility** — recognizes legacy `extension.config.json` extensions, handles the nested `theme-app/` theme layout, warns when an extension's config names a different app than the deploy target, and migrates v1 configs to `shoplazza.extension.toml` on deploy (old JSON marked deprecated, not deleted).
- `app config link` now auto-activates the linked config — no separate `app config use` step needed.
- Analytics endpoints gain a `filter_crawler_type` param to exclude known bot/crawler traffic from statistics (`no_filter_crawler` default / `official_crawler`).

## Changed
- `theme-extension connect` no longer needs `--partner`: it derives the app's partner from `--client-id` (consistent with `theme-extension release` and `app config link`). The `--partner` flag was removed.
- `auth status` / `auth login` always include `current_store` (empty `""` when no store is selected), consistent with `granted_scopes`.
- Clearer analytics param descriptions — `begin_time`/`end_time` spell out the string Unix-timestamp format, and `filter`/`filters` document their operator/value rules and supported keys.

## Fixed
- `auth login --store-domain` now validates the store at login: an invalid or inaccessible store yields a clear warning and is not set as the current store, instead of surfacing later as a confusing `404 store_not_found`. Login itself still succeeds.
- `auth login` no longer prints the store warning twice (stderr summary only, not repeated in the JSON).

## Release chore
- `package.json` bumped to `2.0.4`; CHANGELOG `[Unreleased]` promoted to `2.0.4 - 2026-07-03`.
- Registry metadata regenerated (`internal/registry/cli_meta_v202601_en.json`).
- Tag `v2.0.4` to be cut after merge (runtime version comes from the git tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)