### PR TITLE
Release 2.0.6: --domain app theme scopes, partner-token preservation, languages metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **`auth login --domain app`** now expands to the app-extension development scopes — `read_themes write_themes` (plus `read_shop`, which the themes module implies for theme previews) — covering themes, checkout, and theme-extension uploads. Previously it granted the app template's install scopes (`read_customer write_cart_transform`).
+
+### Fixed
+- **Partner token no longer dropped by routine logins** — a store-scoped or `--uat` login of the same account carries no partner token, but it used to wipe the stored one, forcing an interactive re-login for every `app` command. It is now preserved for the same account and cleared only on an account switch or explicit logout.
+
 ## 2.0.5 - 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 2.0.6 - 2026-07-07
 
 ### Changed
 - **`auth login --domain app`** now expands to the app-extension development scopes — `read_themes write_themes` (plus `read_shop`, which the themes module implies for theme previews) — covering themes, checkout, and theme-extension uploads. Previously it granted the app template's install scopes (`read_customer write_cart_transform`).

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -159,13 +159,13 @@ func expandLoginDomains(domains []string) ([]string, error) {
 	var appScopes []string
 	for _, d := range domains {
 		if d == "app" {
-			for _, sub := range []string{"themes", "checkout"} {
-				s, err := internalauth.ExpandDomain(sub)
-				if err != nil {
-					return nil, err
-				}
-				appScopes = append(appScopes, s...)
+			// themes, checkout, and theme-extension uploads all authorize via the
+			// themes scope, so that single domain covers app-extension development.
+			s, err := internalauth.ExpandDomain("themes")
+			if err != nil {
+				return nil, err
 			}
+			appScopes = append(appScopes, s...)
 			continue
 		}
 		rest = append(rest, d)

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"shoplazza-cli-v2/internal/app/project"
 	internalauth "shoplazza-cli-v2/internal/auth"
 	"shoplazza-cli-v2/internal/cmdutil"
 	"shoplazza-cli-v2/internal/output"
@@ -152,15 +151,21 @@ func domainFlagHelp() string {
 
 // expandLoginDomains expands --domain values into OAuth scopes. Beyond the
 // API-module domains handled by internalauth.ExpandDomains, it accepts the
-// alias "app": the scopes a scaffolded app requests by default
-// (project.DefaultScopes), so `auth login -s <store> --domain app` grants a
-// test store exactly what the app template ships with.
+// alias "app": the scopes app-extension development needs. themes, checkout,
+// and theme-extension uploads all authorize via the themes scope, so
+// `auth login -s <store> --domain app` grants read_themes + write_themes.
 func expandLoginDomains(domains []string) ([]string, error) {
 	rest := make([]string, 0, len(domains))
 	var appScopes []string
 	for _, d := range domains {
 		if d == "app" {
-			appScopes = strings.Fields(project.DefaultScopes)
+			for _, sub := range []string{"themes", "checkout"} {
+				s, err := internalauth.ExpandDomain(sub)
+				if err != nil {
+					return nil, err
+				}
+				appScopes = append(appScopes, s...)
+			}
 			continue
 		}
 		rest = append(rest, d)
@@ -169,7 +174,7 @@ func expandLoginDomains(domains []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return append(scopes, appScopes...), nil
+	return internalauth.DedupePreserveOrder(append(scopes, appScopes...)), nil
 }
 
 func newCmdLogout(f *cmdutil.Factory) *cobra.Command {

--- a/cmd/auth/login_scopes_internal_test.go
+++ b/cmd/auth/login_scopes_internal_test.go
@@ -19,14 +19,15 @@ func containsAll(got []string, want ...string) bool {
 	return true
 }
 
-// --domain app expands to the app template's default install scopes.
+// --domain app expands to the app-extension development scopes: themes,
+// checkout, and theme-extension uploads all authorize via the themes scope.
 func TestExpandLoginDomains_AppAlias(t *testing.T) {
 	got, err := expandLoginDomains([]string{"app"})
 	if err != nil {
 		t.Fatalf("expandLoginDomains([app]): %v", err)
 	}
-	if !containsAll(got, "read_customer", "write_cart_transform") {
-		t.Fatalf("--domain app = %v, want read_customer + write_cart_transform", got)
+	if !containsAll(got, "read_themes", "write_themes") {
+		t.Fatalf("--domain app = %v, want read_themes + write_themes", got)
 	}
 }
 
@@ -49,7 +50,7 @@ func TestExpandLoginDomains_AppPlusModule(t *testing.T) {
 		t.Fatalf("expandLoginDomains([app,products]): %v", err)
 	}
 	prod, _ := internalauth.ExpandDomains([]string{"products"})
-	want := append([]string{"read_customer", "write_cart_transform"}, prod...)
+	want := append([]string{"read_themes", "write_themes"}, prod...)
 	if !containsAll(got, want...) {
 		t.Fatalf("--domain app,products = %v, want union %v", got, want)
 	}

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -522,10 +522,11 @@ func TestE2E_Login_StoreUse_Refresh_Logout(t *testing.T) {
 }
 
 // A non-interactive `auth login --uat` cannot obtain a partner token (those are
-// only minted at interactive consent). It must not leave a stale partner
-// token from a prior interactive login behind — LoadState reads the partner
-// keychain entry unconditionally, so a lingering entry would be resurrected.
-func TestLoginUAT_ClearsStalePartnerToken(t *testing.T) {
+// only minted at interactive consent). For the SAME account it must PRESERVE an
+// existing partner token from a prior interactive login rather than wiping it —
+// otherwise a routine re-login would force a fresh interactive consent for every
+// app command. (An account switch still clears it; see persistState.)
+func TestLoginUAT_PreservesPartnerTokenSameAccount(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -553,21 +554,21 @@ func TestLoginUAT_ClearsStalePartnerToken(t *testing.T) {
 		t.Fatalf("setup: expected partner token after interactive login, got %q", st.Partner)
 	}
 
-	// 2. Non-interactive --uat re-login produces no partner token.
+	// 2. Non-interactive --uat re-login of the SAME account produces no partner token.
 	if _, err := mgr.Login(context.Background(), "", nil, "uat_injected", 5*time.Second, time.Millisecond, nil); err != nil {
 		t.Fatalf("uat login: %v", err)
 	}
 
-	// 3. The stale partner token must not be resurrected by LoadState...
+	// 3. The same account's partner token is preserved (not wiped), so app
+	// commands keep working without a fresh interactive login.
 	st, err := mgr.LoadState()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if st.Partner != "" {
-		t.Errorf("stale partner token resurrected after --uat re-login: %q", st.Partner)
+	if st.Partner != "pt_stale" {
+		t.Errorf("partner token should be preserved across a same-account --uat re-login, got %q", st.Partner)
 	}
-	// ...and must be gone from the keychain entirely.
-	if got, _ := keychain.Get(keychain.ShoplazzaCliService, "partner"); got != "" {
-		t.Errorf("partner keychain entry should be removed when login yields no partner, got %q", got)
+	if got, _ := keychain.Get(keychain.ShoplazzaCliService, "partner"); got != "pt_stale" {
+		t.Errorf("partner keychain entry should be preserved for the same account, got %q", got)
 	}
 }

--- a/internal/auth/persist.go
+++ b/internal/auth/persist.go
@@ -23,11 +23,26 @@ func storeKcKey(domain string) string { return "store:" + domain }
 func appKcKey(clientID string) string { return "app:" + clientID }
 
 func (m *Manager) persistState(state AuthState) error {
+	// A login/refresh that carries no partner token must not silently drop an
+	// existing one for the SAME account. A routine store-scoped login (whose poll
+	// returns no partner_token) or a --uat refresh would otherwise cost you your
+	// partner session and force an interactive re-login for every app command.
+	// Preserve it here; it is only cleared on an account switch (below — else
+	// LoadState would resurrect another account's partner token) or on explicit
+	// logout (Logout removes it directly).
+	partner, partnerExpiresAt := state.Partner, state.PartnerExpiresAt
+	if partner == "" {
+		if prev, err := loadAuthMeta(m.AuthPath); err == nil && prev.Account != "" && prev.Account == state.Account {
+			if existing, gerr := keychain.Get(keychain.ShoplazzaCliService, kcPartner); gerr == nil && existing != "" {
+				partner, partnerExpiresAt = existing, prev.PartnerExpiresAt
+			}
+		}
+	}
 	meta := authMeta{
 		Account:          state.Account,
 		UserID:           state.UserID,
 		UATExpiresAt:     state.UATExpiresAt,
-		PartnerExpiresAt: state.PartnerExpiresAt,
+		PartnerExpiresAt: partnerExpiresAt,
 		GrantedScopes:    state.GrantedScopes,
 		Stores:           map[string]StoreTokenMeta{},
 		Apps:             map[string]AppTokenMeta{},
@@ -46,16 +61,14 @@ func (m *Manager) persistState(state AuthState) error {
 			return err
 		}
 	}
-	if state.Partner != "" {
-		if err := keychain.Set(keychain.ShoplazzaCliService, kcPartner, state.Partner); err != nil {
+	if partner != "" {
+		if err := keychain.Set(keychain.ShoplazzaCliService, kcPartner, partner); err != nil {
 			return err
 		}
 	} else {
-		// A login that yields no partner token (e.g. --uat, or a failed
-		// best-effort mint) must not leave a stale partner credential behind:
-		// LoadState reads kcPartner unconditionally, so a lingering entry would be
-		// resurrected. Store-token operations (UseStore/RefreshAccessToken)
-		// LoadState first, so a genuinely-present partner is preserved, not dropped.
+		// Empty here means either a first login with no partner token, or an
+		// account switch — drop any lingering entry so LoadState can't resurrect
+		// a different account's partner token.
 		_ = keychain.Remove(keychain.ShoplazzaCliService, kcPartner)
 	}
 	for dom, s := range state.Stores {

--- a/internal/auth/persist.go
+++ b/internal/auth/persist.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"shoplazza-cli-v2/internal/core"
 	"shoplazza-cli-v2/internal/keychain"
@@ -32,7 +33,9 @@ func (m *Manager) persistState(state AuthState) error {
 	// logout (Logout removes it directly).
 	partner, partnerExpiresAt := state.Partner, state.PartnerExpiresAt
 	if partner == "" {
-		if prev, err := loadAuthMeta(m.AuthPath); err == nil && prev.Account != "" && prev.Account == state.Account {
+		// Match case-insensitively: poll and Me may echo the same email in
+		// different casing, and a mismatch would wrongly wipe a valid token.
+		if prev, err := loadAuthMeta(m.AuthPath); err == nil && prev.Account != "" && strings.EqualFold(prev.Account, state.Account) {
 			if existing, gerr := keychain.Get(keychain.ShoplazzaCliService, kcPartner); gerr == nil && existing != "" {
 				partner, partnerExpiresAt = existing, prev.PartnerExpiresAt
 			}

--- a/internal/auth/persist_partner_internal_test.go
+++ b/internal/auth/persist_partner_internal_test.go
@@ -48,3 +48,31 @@ func TestPersistState_PreservesPartnerAcrossSameAccountLogin(t *testing.T) {
 		t.Fatalf("partner token should be cleared on account switch, got %q", got)
 	}
 }
+
+// The interactive and --uat login paths read the account from different backend
+// endpoints (poll vs. Me), which may echo the same email with different casing.
+// Preservation must match accounts case-insensitively, else a casing mismatch
+// silently wipes a still-valid partner token — the exact regression this guards.
+func TestPersistState_PreservesPartnerAcrossAccountCasing(t *testing.T) {
+	testenv.IsolateConfigDir(t)
+	dir := t.TempDir()
+	m := &Manager{
+		Config:     core.CliConfig{},
+		ConfigPath: filepath.Join(dir, "config.json"),
+		AuthPath:   filepath.Join(dir, "auth.json"),
+	}
+
+	if err := m.persistState(AuthState{
+		Account: "User@X.com", UAT: "uat_a",
+		Partner: "ptok_a", PartnerExpiresAt: "2099-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Same human, but the Me endpoint returns the email lower-cased.
+	if err := m.persistState(AuthState{Account: "user@x.com", UAT: "uat_a"}); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := keychain.Get(keychain.ShoplazzaCliService, kcPartner); got != "ptok_a" {
+		t.Fatalf("partner token wiped by account casing difference: got %q, want ptok_a", got)
+	}
+}

--- a/internal/auth/persist_partner_internal_test.go
+++ b/internal/auth/persist_partner_internal_test.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"path/filepath"
+	"testing"
+
+	"shoplazza-cli-v2/internal/core"
+	"shoplazza-cli-v2/internal/keychain"
+	"shoplazza-cli-v2/internal/testenv"
+)
+
+// A store-scoped or --uat login of the SAME account carries no partner token;
+// it must NOT wipe the existing one (that used to force a re-login for every
+// app command). An account switch still clears it.
+func TestPersistState_PreservesPartnerAcrossSameAccountLogin(t *testing.T) {
+	testenv.IsolateConfigDir(t)
+	dir := t.TempDir()
+	m := &Manager{
+		Config:     core.CliConfig{},
+		ConfigPath: filepath.Join(dir, "config.json"),
+		AuthPath:   filepath.Join(dir, "auth.json"),
+	}
+
+	// 1. Interactive login mints a partner token for account A.
+	if err := m.persistState(AuthState{
+		Account: "a@x.com", UAT: "uat_a",
+		Partner: "ptok_a", PartnerExpiresAt: "2099-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. A routine store-scoped login of the SAME account returns no partner token.
+	if err := m.persistState(AuthState{
+		Account: "a@x.com", UAT: "uat_a", CurrentStore: "s.myshoplazza.com",
+		Stores: map[string]StoreState{"s.myshoplazza.com": {Token: "stok", ExpiresAt: "2099-01-01T00:00:00Z"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := keychain.Get(keychain.ShoplazzaCliService, kcPartner); got != "ptok_a" {
+		t.Fatalf("partner token wiped by same-account store login: got %q, want ptok_a", got)
+	}
+
+	// 3. Switching to a DIFFERENT account with no partner token clears it.
+	if err := m.persistState(AuthState{Account: "b@y.com", UAT: "uat_b"}); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := keychain.Get(keychain.ShoplazzaCliService, kcPartner); got != "" {
+		t.Fatalf("partner token should be cleared on account switch, got %q", got)
+	}
+}

--- a/internal/registry/cli_meta_v202601_en.json
+++ b/internal/registry/cli_meta_v202601_en.json
@@ -1,6 +1,6 @@
 {
   "version": "v202601",
-  "generated_at": "2026-07-03T02:40:28Z",
+  "generated_at": "2026-07-06T10:22:47Z",
   "modules": [
     {
       "name": "billing",
@@ -6341,6 +6341,10 @@
           "summary": "Query and update core store settings and shop profile.",
           "description": "A shop represents a merchant's store and holds the account, contact, locale, currency,\ndomain, and subscription settings that other resources reference.\nProvides endpoints to retrieve shop details and update shop attributes."
         },
+        "languages": {
+          "summary": "Manage a store's languages: add, enable, disable, publish to markets, and delete.",
+          "description": "Store languages are the locales available in a merchant's store. Each language can be enabled\n(visible to storefront visitors) or disabled, and can be published to one or more markets.\nNewly added languages are disabled by default and must be enabled before they take effect.\nProvides endpoints to list languages with their market relations, add languages, enable or\ndisable them, publish them to markets, and delete them. Deleting only removes configuration;\nthe translation corpus is retained."
+        },
         "metafields-definition": {
           "summary": "Define and manage metafield schemas that extend resource objects with custom data.",
           "description": "Metafield definitions describe the schema of metafields attached to a given owner resource,\nincluding namespace, key, value type, and validation, so that merchants and apps can store\ncustom data in a consistent, typed way.\nProvides endpoints to create, update, get, list, delete metafield definitions, and to count\ndefinitions or their associated metafields by owner resource or group."
@@ -6670,7 +6674,7 @@
               {
                 "name": "filter",
                 "type": "string",
-                "description": "Advanced filter conditions as a JSON string. Only takes effect when `search_model` is \"advanced\". A flat JSON object that maps each filter key to a leaf {\"operator\": \"...\", \"value\": ...}; multiple keys are combined with AND (this endpoint does not support OR groups). The `value` type to send depends on the operator (operators are case-insensitive): - `in`, `not in`             -\u003e value is an ARRAY of strings, e.g. [\"SPU001\", \"SPU002\"] - `like`, `not like`         -\u003e value is a STRING, e.g. \"shirt\" - `=`, `\u003e`, `\u003e=`, `\u003c`, `\u003c=`  -\u003e value is a SCALAR (string or number), e.g. 10 Key -\u003e expected value: list keys (`spu`, `sku`, `product_id`, `title`, `tag_list`) use the array form; range keys (`price_min`/`price_max`, `cost_price_min`/`cost_price_max`, `compare_at_price_min`/`compare_at_price_max`, `created_at_min`/`created_at_max`, `updated_at_min`/`updated_at_max`) use a scalar; boolean keys (`published`, `sub_category`) use \"true\"/\"false\"; other keys (`collection_id`, `keyword`, `vendor`, `category`, `product_note`, `sales_platform`) use a string. Unknown keys are silently ignored (the request still returns 200), so a filter \"not taking effect\" usually means a mistyped key. e.g. {\"spu\": {\"operator\": \"in\", \"value\": [\"SPU001\", \"SPU002\"]}}"
+                "description": "Advanced filter conditions as a JSON string. Only takes effect when `search_model` is \"advanced\". Structure: a flat JSON object that maps each filter key to a leaf `{\"operator\": \"...\", \"value\": ...}`; multiple keys are combined with AND (this endpoint does not support OR groups). The `value` type to send depends on the operator (operators are case-insensitive): - `in` / `not in` -\u003e value is an ARRAY of strings, e.g. `[\"SPU001\", \"SPU002\"]` - `like` / `not like` -\u003e value is a STRING, e.g. `\"shirt\"` - `=` `\u003e` `\u003e=` `\u003c` `\u003c=` -\u003e value is a SCALAR (string or number), e.g. `10` Key -\u003e expected value: - list keys `spu` `sku` `product_id` `title` `tag_list` -\u003e array - range keys `price_min`/`price_max`, `cost_price_min`/`cost_price_max`, `compare_at_price_min`/`compare_at_price_max`, `created_at_min`/`created_at_max`, `updated_at_min`/`updated_at_max` -\u003e scalar - boolean keys `published` `sub_category` -\u003e `\"true\"` / `\"false\"` - other keys `collection_id` `keyword` `vendor` `category` `product_note` `sales_platform` -\u003e string Unknown keys are silently ignored (the request still returns 200), so a filter \"not taking effect\" usually means a mistyped key. e.g. `{\"spu\": {\"operator\": \"in\", \"value\": [\"SPU001\", \"SPU002\"]}}`"
               },
               {
                 "name": "with_impression",
@@ -7538,6 +7542,830 @@
             ]
           },
           "response_schema": "v202506.UpdateShopResponse"
+        },
+        {
+          "id": "language-add",
+          "command_path": [
+            "languages",
+            "add"
+          ],
+          "summary": "Add store languages",
+          "description": "Add one or more store languages. Newly added languages are disabled by default.",
+          "hidden": false,
+          "http": {
+            "method": "POST",
+            "path": "/openapi/2026-01/languages",
+            "body": "*"
+          },
+          "body": {
+            "required": true,
+            "fields": [
+              {
+                "name": "codes",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "required": true,
+                "description": "IETF language codes to add (e.g., [\"zh-CN\", \"ja-JP\"]). Each code must be one of the system supported languages; unsupported codes are silently dropped.",
+                "min_length": 1
+              }
+            ]
+          },
+          "response_schema": "v202601.AddLanguagesResponse"
+        },
+        {
+          "id": "language-delete",
+          "command_path": [
+            "languages",
+            "delete"
+          ],
+          "summary": "Delete store language",
+          "description": "Delete a store language. The language must be disabled first; only its configuration is removed and the translation corpus is retained.",
+          "hidden": false,
+          "http": {
+            "method": "DELETE",
+            "path": "/openapi/2026-01/languages/{language_code}"
+          },
+          "parameters": [
+            {
+              "name": "language_code",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "IETF language code.",
+              "min_length": 1
+            }
+          ],
+          "response_schema": "v202601.DeleteLanguageResponse"
+        },
+        {
+          "id": "language-disable",
+          "command_path": [
+            "languages",
+            "disable"
+          ],
+          "summary": "Disable store language",
+          "description": "Disable a store language so it is hidden from visitors; configuration and translations are kept. A store must keep at least one enabled language; a primary market's default language and a market's last enabled language cannot be disabled.",
+          "hidden": false,
+          "http": {
+            "method": "POST",
+            "path": "/openapi/2026-01/languages/{language_code}/disable",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "language_code",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "IETF language code.",
+              "min_length": 1
+            }
+          ],
+          "response_schema": "v202601.DisableLanguageResponse"
+        },
+        {
+          "id": "language-enable",
+          "command_path": [
+            "languages",
+            "enable"
+          ],
+          "summary": "Enable store language",
+          "description": "Enable a store language so it is visible to storefront visitors.",
+          "hidden": false,
+          "http": {
+            "method": "POST",
+            "path": "/openapi/2026-01/languages/{language_code}/enable",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "language_code",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "IETF language code.",
+              "min_length": 1
+            }
+          ],
+          "response_schema": "v202601.EnableLanguageResponse"
+        },
+        {
+          "id": "languages",
+          "command_path": [
+            "languages",
+            "list"
+          ],
+          "summary": "List store languages",
+          "description": "Retrieve store languages together with their market relations.",
+          "hidden": false,
+          "http": {
+            "method": "GET",
+            "path": "/openapi/2026-01/languages"
+          },
+          "response_schema": "v202601.ListLanguagesResponse"
+        },
+        {
+          "id": "language-markets",
+          "command_path": [
+            "languages",
+            "markets"
+          ],
+          "summary": "List configurable markets",
+          "description": "List the markets a language can be configured (published) to. Use this before publishing a language to markets.",
+          "hidden": false,
+          "http": {
+            "method": "GET",
+            "path": "/openapi/2026-01/languages/markets"
+          },
+          "response_schema": "v202601.ListLanguageMarketsResponse"
+        },
+        {
+          "id": "language-publish",
+          "command_path": [
+            "languages",
+            "publish"
+          ],
+          "summary": "Publish language to markets",
+          "description": "Configure a language to one or more markets. Full replacement of market relations; an empty list removes all relations. A disabled language can be configured but does not take effect until enabled.",
+          "hidden": false,
+          "http": {
+            "method": "POST",
+            "path": "/openapi/2026-01/languages/{language_code}/publish",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "language_code",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "IETF language code.",
+              "min_length": 1
+            }
+          ],
+          "body": {
+            "fields": [
+              {
+                "name": "market_ids",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Market IDs this language is configured to. Full replacement, NOT incremental. An empty array removes all market relations of this language."
+              }
+            ]
+          },
+          "response_schema": "v202601.PublishLanguageToMarketsResponse"
+        },
+        {
+          "id": "supported-languages",
+          "command_path": [
+            "languages",
+            "supported"
+          ],
+          "summary": "List supported languages",
+          "description": "List the languages the system supports. Use this to validate language codes before adding them; codes not in this list are silently dropped on add.",
+          "hidden": false,
+          "http": {
+            "method": "GET",
+            "path": "/openapi/2026-01/languages/supported"
+          },
+          "response_schema": "v202601.ListSupportedLanguagesResponse"
+        },
+        {
+          "id": "market-products-delete",
+          "command_path": [
+            "market",
+            "delete-product"
+          ],
+          "summary": "Delete market products",
+          "description": "Remove products from a market so the market stops selling them.",
+          "hidden": false,
+          "http": {
+            "method": "DELETE",
+            "path": "/openapi/2026-01/markets/{id}/products",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            }
+          ],
+          "body": {
+            "required": true,
+            "fields": [
+              {
+                "name": "product_ids",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "required": true,
+                "description": "Product IDs to remove from this market.",
+                "min_length": 1
+              }
+            ]
+          },
+          "response_schema": "v202601.DeleteMarketProductsResponse"
+        },
+        {
+          "id": "market-products-add",
+          "command_path": [
+            "markets",
+            "add-product"
+          ],
+          "summary": "Add market products",
+          "description": "Add products to a market so the market sells them.",
+          "hidden": false,
+          "http": {
+            "method": "POST",
+            "path": "/openapi/2026-01/markets/{id}/products",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            }
+          ],
+          "body": {
+            "required": true,
+            "fields": [
+              {
+                "name": "product_ids",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "required": true,
+                "description": "Product IDs to add to this market.",
+                "min_length": 1
+              }
+            ]
+          },
+          "response_schema": "v202601.AddMarketProductsResponse"
+        },
+        {
+          "id": "market-create",
+          "command_path": [
+            "markets",
+            "create"
+          ],
+          "summary": "Create market",
+          "description": "Create a market with a name and covered countries.",
+          "hidden": false,
+          "http": {
+            "method": "POST",
+            "path": "/openapi/2026-01/markets",
+            "body": "*"
+          },
+          "body": {
+            "required": true,
+            "fields": [
+              {
+                "name": "name",
+                "type": "string",
+                "required": true,
+                "description": "Market name. Maximum 50 characters. Must be unique within the store.",
+                "min_length": 1,
+                "max_length": 50
+              },
+              {
+                "name": "countries",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "required": true,
+                "description": "Covered countries, ISO 3166-1 alpha-2 codes in upper case (e.g., US, JP). A country may belong to only one market.",
+                "min_length": 1
+              },
+              {
+                "name": "confirm",
+                "type": "boolean",
+                "description": "Confirmation flag. When false (default) and any country is already occupied by other markets, the request is rejected and the markets that would be deleted are returned. Resubmit with true to proceed; those occupied markets will be automatically deleted."
+              }
+            ]
+          },
+          "response_schema": "v202601.CreateMarketResponse"
+        },
+        {
+          "id": "market-delete",
+          "command_path": [
+            "markets",
+            "delete"
+          ],
+          "summary": "Delete market",
+          "description": "Permanently delete a market. The primary market cannot be deleted; deletion is irreversible.",
+          "hidden": false,
+          "http": {
+            "method": "DELETE",
+            "path": "/openapi/2026-01/markets/{id}"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID. The primary market cannot be deleted. Deletion is irreversible.",
+              "min_length": 1
+            }
+          ],
+          "response_schema": "v202601.DeleteMarketResponse"
+        },
+        {
+          "id": "market-detail",
+          "command_path": [
+            "markets",
+            "get"
+          ],
+          "summary": "Get market",
+          "description": "Retrieve full detail of a single market, including domain, pricing, tax, language and status.",
+          "hidden": false,
+          "http": {
+            "method": "GET",
+            "path": "/openapi/2026-01/markets/{id}"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            }
+          ],
+          "response_schema": "v202601.GetMarketResponse"
+        },
+        {
+          "id": "markets",
+          "command_path": [
+            "markets",
+            "list"
+          ],
+          "summary": "List markets",
+          "description": "Retrieve all markets of the store with their configuration.",
+          "hidden": false,
+          "http": {
+            "method": "GET",
+            "path": "/openapi/2026-01/markets"
+          },
+          "parameters": [
+            {
+              "name": "only_active",
+              "in": "query",
+              "type": "boolean",
+              "description": "Whether to return only active markets. Defaults to false."
+            },
+            {
+              "name": "with_countries_detail",
+              "in": "query",
+              "type": "boolean",
+              "description": "Whether to include per-country currency detail. Defaults to false."
+            }
+          ],
+          "response_schema": "v202601.ListMarketsResponse"
+        },
+        {
+          "id": "market-languages",
+          "command_path": [
+            "markets",
+            "list-language"
+          ],
+          "summary": "List market languages",
+          "description": "List the languages configured on a market, including each language's enabled and default status. Use this before setting the market's default language.",
+          "hidden": false,
+          "http": {
+            "method": "GET",
+            "path": "/openapi/2026-01/markets/{id}/languages"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            }
+          ],
+          "response_schema": "v202601.ListMarketLanguagesResponse"
+        },
+        {
+          "id": "market-products",
+          "command_path": [
+            "markets",
+            "list-product"
+          ],
+          "summary": "List market products",
+          "description": "List the products of a market, this returns each product's on-sale status in this market and its price in the market's currency.",
+          "hidden": false,
+          "http": {
+            "method": "GET",
+            "path": "/openapi/2026-01/markets/{id}/products"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            },
+            {
+              "name": "is_excluded",
+              "in": "query",
+              "type": "boolean",
+              "description": "Filter by exclusion status: true returns only excluded products, false returns only included products, omit to return all."
+            },
+            {
+              "name": "keyword",
+              "in": "query",
+              "type": "string",
+              "description": "Search keyword matched against product title."
+            },
+            {
+              "name": "collection_id",
+              "in": "query",
+              "type": "string",
+              "description": "Filter products belonging to a specific collection."
+            },
+            {
+              "name": "sort_by",
+              "in": "query",
+              "type": "string",
+              "description": "Field to sort by."
+            },
+            {
+              "name": "sort_direction",
+              "in": "query",
+              "type": "string",
+              "description": "Sort direction (e.g., asc or desc)."
+            },
+            {
+              "name": "cursor",
+              "in": "query",
+              "type": "string",
+              "description": "Cursor for pagination."
+            },
+            {
+              "name": "page_size",
+              "in": "query",
+              "type": "integer",
+              "format": "int32",
+              "description": "A limit on the number of objects to return. Range: 1-100 (default is 10).",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100
+            }
+          ],
+          "response_schema": "v202601.ListMarketProductsResponse"
+        },
+        {
+          "id": "market-preview",
+          "command_path": [
+            "markets",
+            "preview"
+          ],
+          "summary": "Preview markets to be deleted",
+          "description": "Given a set of countries, preview which existing markets would be fully claimed and therefore automatically deleted. Call this before creating or updating a market so the caller knows which markets will be removed.",
+          "hidden": false,
+          "http": {
+            "method": "POST",
+            "path": "/openapi/2026-01/markets/preview",
+            "body": "*"
+          },
+          "body": {
+            "required": true,
+            "fields": [
+              {
+                "name": "countries",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "required": true,
+                "description": "Countries to claim, ISO 3166-1 alpha-2 codes in upper case (e.g., US, JP). Because a country may belong to only one market, any other market whose countries are all claimed here will be automatically deleted.",
+                "min_length": 1
+              },
+              {
+                "name": "except_market_id",
+                "type": "string",
+                "description": "Market ID to exclude from the check."
+              }
+            ]
+          },
+          "response_schema": "v202601.PreviewMarketResponse"
+        },
+        {
+          "id": "market-update",
+          "command_path": [
+            "markets",
+            "update"
+          ],
+          "summary": "Update market",
+          "description": "Update a market's name or covered countries.",
+          "hidden": false,
+          "http": {
+            "method": "PUT",
+            "path": "/openapi/2026-01/markets/{id}",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            }
+          ],
+          "body": {
+            "fields": [
+              {
+                "name": "name",
+                "type": "string",
+                "description": "New market name. Maximum 50 characters. Omit to keep unchanged.",
+                "max_length": 50
+              },
+              {
+                "name": "countries",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Covered countries (ISO 3166-1 alpha-2 upper case). Full replacement, NOT incremental. Omit to keep unchanged."
+              },
+              {
+                "name": "confirm",
+                "type": "boolean",
+                "description": "Confirmation flag for country occupation, same semantics as in market creation."
+              }
+            ]
+          },
+          "response_schema": "v202601.UpdateMarketResponse"
+        },
+        {
+          "id": "market-default-language-update",
+          "command_path": [
+            "markets",
+            "update-default-language"
+          ],
+          "summary": "Update market default language",
+          "description": "Set the default language of a market. The language must already be published to the market and enabled.",
+          "hidden": false,
+          "http": {
+            "method": "PUT",
+            "path": "/openapi/2026-01/markets/{id}/default-language",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            }
+          ],
+          "body": {
+            "required": true,
+            "fields": [
+              {
+                "name": "language_code",
+                "type": "string",
+                "required": true,
+                "description": "IETF language code (e.g., zh-CN). The language must already be published to this market and enabled. For the primary market, changing the default language also changes the store default language.",
+                "min_length": 1
+              }
+            ]
+          },
+          "response_schema": "v202601.UpdateMarketDefaultLanguageResponse"
+        },
+        {
+          "id": "market-domain-update",
+          "command_path": [
+            "markets",
+            "update-domain"
+          ],
+          "summary": "Update market domain",
+          "description": "Change a market's domain mode (primary domain or sub-path).",
+          "hidden": false,
+          "http": {
+            "method": "PUT",
+            "path": "/openapi/2026-01/markets/{id}/domain",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            }
+          ],
+          "body": {
+            "required": true,
+            "fields": [
+              {
+                "name": "domain_type",
+                "type": "string",
+                "required": true,
+                "description": "Domain mode. Allowed values: - primary: use a primary (independent) domain. - sub_path: use a sub-path suffix under the primary domain. For a non-primary market, switching domain_type deletes all existing language configurations of this market and re-copies them from the primary market."
+              },
+              {
+                "name": "domain_value",
+                "type": "string",
+                "description": "Domain value. Maximum 255 characters; letters, digits and underscore only. Required when domain_type is sub_path. The sub-path must not clash with a language code abbreviation (e.g., ca).",
+                "max_length": 255
+              }
+            ]
+          },
+          "response_schema": "v202601.UpdateMarketDomainResponse"
+        },
+        {
+          "id": "market-price-update",
+          "command_path": [
+            "markets",
+            "update-price"
+          ],
+          "summary": "Update market price",
+          "description": "Change a market's base currency, price adjustment and local-currency display. Custom exchange rate is not supported.",
+          "hidden": false,
+          "http": {
+            "method": "PUT",
+            "path": "/openapi/2026-01/markets/{id}/price",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            }
+          ],
+          "body": {
+            "required": true,
+            "fields": [
+              {
+                "name": "currency",
+                "type": "string",
+                "required": true,
+                "description": "Base currency, ISO 4217 three-letter code in upper case (e.g., USD). Must be supplied with the current currency even when only adjusting price. Switching currency clears all fixed prices already set for products in this market."
+              },
+              {
+                "name": "price_adjust",
+                "type": "integer",
+                "format": "int32",
+                "description": "Price adjustment percentage. Range -99 to 999; positive raises price, negative lowers it. Pass 0 for no adjustment.",
+                "minimum": -99,
+                "maximum": 999
+              },
+              {
+                "name": "local_currency_enabled",
+                "type": "boolean",
+                "description": "Whether the local-currency display is enabled for this market."
+              }
+            ]
+          },
+          "response_schema": "v202601.UpdateMarketPriceResponse"
+        },
+        {
+          "id": "market-products-price-update",
+          "command_path": [
+            "markets",
+            "update-product-price"
+          ],
+          "summary": "Update market product prices",
+          "description": "Set or remove fixed prices of products in a market.",
+          "hidden": false,
+          "http": {
+            "method": "PUT",
+            "path": "/openapi/2026-01/markets/{id}/products/price",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            }
+          ],
+          "body": {
+            "required": true,
+            "fields": [
+              {
+                "name": "products",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "schema": "v202601.MarketProductPriceItem"
+                },
+                "required": true,
+                "description": "Per-product fixed-price operations.",
+                "min_length": 1
+              }
+            ]
+          },
+          "response_schema": "v202601.UpdateMarketProductPricesResponse"
+        },
+        {
+          "id": "market-status-update",
+          "command_path": [
+            "markets",
+            "update-status"
+          ],
+          "summary": "Update market status",
+          "description": "Enable or pause a market. The primary market cannot be paused; pausing a market prevents customers from checking out.",
+          "hidden": false,
+          "http": {
+            "method": "PUT",
+            "path": "/openapi/2026-01/markets/{id}/status",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            }
+          ],
+          "body": {
+            "required": true,
+            "fields": [
+              {
+                "name": "status",
+                "type": "string",
+                "required": true,
+                "description": "Market status. Allowed values: - active: market is enabled. - paused: market is paused; customers cannot check out. The primary market cannot be paused."
+              }
+            ]
+          },
+          "response_schema": "v202601.UpdateMarketStatusResponse"
+        },
+        {
+          "id": "market-tax-update",
+          "command_path": [
+            "markets",
+            "update-tax"
+          ],
+          "summary": "Update market tax",
+          "description": "Change whether product prices include tax. This is the only update allowed on the primary market.",
+          "hidden": false,
+          "http": {
+            "method": "PUT",
+            "path": "/openapi/2026-01/markets/{id}/tax",
+            "body": "*"
+          },
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "type": "string",
+              "required": true,
+              "description": "Market ID.",
+              "min_length": 1
+            }
+          ],
+          "body": {
+            "required": true,
+            "fields": [
+              {
+                "name": "product_tax_included",
+                "type": "boolean",
+                "required": true,
+                "description": "Whether product prices already include tax."
+              }
+            ]
+          },
+          "response_schema": "v202601.UpdateMarketTaxResponse"
         },
         {
           "id": "metafield-definition-count",
@@ -19832,6 +20660,8 @@
         }
       ]
     },
+    "v202601.AddLanguagesResponse": {},
+    "v202601.AddMarketProductsResponse": {},
     "v202601.AdditionItem": {
       "fields": [
         {
@@ -20058,6 +20888,30 @@
         }
       ]
     },
+    "v202601.ConfigurableMarket": {
+      "fields": [
+        {
+          "name": "id",
+          "type": "string"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "is_primary",
+          "type": "boolean"
+        },
+        {
+          "name": "market_status",
+          "type": "string"
+        },
+        {
+          "name": "language_manageable",
+          "type": "boolean"
+        }
+      ]
+    },
     "v202601.CreateCollectionParam": {
       "fields": [
         {
@@ -20131,6 +20985,15 @@
           "name": "collection",
           "type": "object",
           "schema": "v202601.Collection"
+        }
+      ]
+    },
+    "v202601.CreateMarketResponse": {
+      "fields": [
+        {
+          "name": "market",
+          "type": "object",
+          "schema": "v202601.Market"
         }
       ]
     },
@@ -20407,6 +21270,10 @@
       ]
     },
     "v202601.DeleteCollectionResponse": {},
+    "v202601.DeleteLanguageResponse": {},
+    "v202601.DeleteMarketProductsResponse": {},
+    "v202601.DeleteMarketResponse": {},
+    "v202601.DisableLanguageResponse": {},
     "v202601.DiscountApplication": {
       "fields": [
         {
@@ -20419,6 +21286,7 @@
         }
       ]
     },
+    "v202601.EnableLanguageResponse": {},
     "v202601.ExtraInfo": {
       "fields": [
         {
@@ -20535,6 +21403,15 @@
         }
       ]
     },
+    "v202601.GetMarketResponse": {
+      "fields": [
+        {
+          "name": "market",
+          "type": "object",
+          "schema": "v202601.Market"
+        }
+      ]
+    },
     "v202601.GetOrderByNumberResponseV202601": {
       "fields": [
         {
@@ -20584,6 +21461,42 @@
         }
       ]
     },
+    "v202601.Language": {
+      "fields": [
+        {
+          "name": "code",
+          "type": "string"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "is_enabled",
+          "type": "boolean"
+        },
+        {
+          "name": "markets",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "schema": "v202601.LanguageMarket"
+          }
+        }
+      ]
+    },
+    "v202601.LanguageMarket": {
+      "fields": [
+        {
+          "name": "id",
+          "type": "string"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        }
+      ]
+    },
     "v202601.ListCollectionResponse": {
       "fields": [
         {
@@ -20601,6 +21514,98 @@
         {
           "name": "has_more",
           "type": "boolean"
+        }
+      ]
+    },
+    "v202601.ListLanguageMarketsResponse": {
+      "fields": [
+        {
+          "name": "markets",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "schema": "v202601.ConfigurableMarket"
+          }
+        }
+      ]
+    },
+    "v202601.ListLanguagesResponse": {
+      "fields": [
+        {
+          "name": "languages",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "schema": "v202601.Language"
+          }
+        }
+      ]
+    },
+    "v202601.ListMarketLanguagesResponse": {
+      "fields": [
+        {
+          "name": "languages",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "schema": "v202601.MarketLanguage"
+          }
+        }
+      ]
+    },
+    "v202601.ListMarketProductsResponse": {
+      "fields": [
+        {
+          "name": "total_count",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "name": "included_count",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "name": "excluded_count",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "name": "currency",
+          "type": "string"
+        },
+        {
+          "name": "symbol",
+          "type": "object",
+          "schema": "v202601.MarketCurrencySymbol"
+        },
+        {
+          "name": "products",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "schema": "v202601.MarketProduct"
+          }
+        },
+        {
+          "name": "cursor",
+          "type": "string"
+        },
+        {
+          "name": "has_more",
+          "type": "boolean"
+        }
+      ]
+    },
+    "v202601.ListMarketsResponse": {
+      "fields": [
+        {
+          "name": "markets",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "schema": "v202601.MarketListItem"
+          }
         }
       ]
     },
@@ -20624,6 +21629,18 @@
         }
       ]
     },
+    "v202601.ListSupportedLanguagesResponse": {
+      "fields": [
+        {
+          "name": "languages",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "schema": "v202601.SupportedLanguage"
+          }
+        }
+      ]
+    },
     "v202601.LocationLine": {
       "fields": [
         {
@@ -20637,6 +21654,315 @@
         {
           "name": "location_name",
           "type": "string"
+        }
+      ]
+    },
+    "v202601.Market": {
+      "fields": [
+        {
+          "name": "id",
+          "type": "string"
+        },
+        {
+          "name": "market_name",
+          "type": "string"
+        },
+        {
+          "name": "is_primary",
+          "type": "boolean"
+        },
+        {
+          "name": "is_default",
+          "type": "boolean"
+        },
+        {
+          "name": "market_status",
+          "type": "string"
+        },
+        {
+          "name": "currency",
+          "type": "string"
+        },
+        {
+          "name": "symbol",
+          "type": "object",
+          "schema": "v202601.MarketCurrencySymbol"
+        },
+        {
+          "name": "domain_type",
+          "type": "string"
+        },
+        {
+          "name": "domain_value",
+          "type": "string"
+        },
+        {
+          "name": "custom_rate_enabled",
+          "type": "boolean"
+        },
+        {
+          "name": "custom_exchange_rate",
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "name": "price_adjust",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "name": "local_currency_enabled",
+          "type": "boolean"
+        },
+        {
+          "name": "product_tax_included",
+          "type": "boolean"
+        },
+        {
+          "name": "default_language",
+          "type": "string"
+        },
+        {
+          "name": "countries",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "languages",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "schema": "v202601.MarketLanguage"
+          }
+        },
+        {
+          "name": "language_manageable",
+          "type": "boolean"
+        },
+        {
+          "name": "url",
+          "type": "string"
+        },
+        {
+          "name": "created_at",
+          "type": "string"
+        },
+        {
+          "name": "updated_at",
+          "type": "string"
+        },
+        {
+          "name": "actual_rate",
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "name": "exchange_rate",
+          "type": "object",
+          "schema": "v202601.MarketExchangeRate"
+        },
+        {
+          "name": "back_exchange_rate",
+          "type": "object",
+          "schema": "v202601.MarketExchangeRate"
+        },
+        {
+          "name": "setting",
+          "type": "object",
+          "schema": "v202601.MarketStorefrontSetting"
+        },
+        {
+          "name": "delivery_country_limited",
+          "type": "boolean"
+        }
+      ]
+    },
+    "v202601.MarketCountry": {
+      "fields": [
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "cn_name",
+          "type": "string"
+        },
+        {
+          "name": "continent",
+          "type": "string"
+        },
+        {
+          "name": "flag",
+          "type": "string"
+        },
+        {
+          "name": "iso_code_2",
+          "type": "string"
+        },
+        {
+          "name": "iso_code_3",
+          "type": "string"
+        }
+      ]
+    },
+    "v202601.MarketCountryCurrencyDetail": {
+      "fields": [
+        {
+          "name": "country_code",
+          "type": "string"
+        },
+        {
+          "name": "currency",
+          "type": "string"
+        },
+        {
+          "name": "symbol",
+          "type": "object",
+          "schema": "v202601.MarketCurrencySymbol"
+        },
+        {
+          "name": "detail",
+          "type": "object",
+          "schema": "v202601.MarketCountry"
+        }
+      ]
+    },
+    "v202601.MarketCurrencySymbol": {
+      "fields": [
+        {
+          "name": "val",
+          "type": "string"
+        },
+        {
+          "name": "left",
+          "type": "string"
+        },
+        {
+          "name": "right",
+          "type": "string"
+        },
+        {
+          "name": "cn_name",
+          "type": "string"
+        },
+        {
+          "name": "title",
+          "type": "string"
+        },
+        {
+          "name": "code",
+          "type": "string"
+        }
+      ]
+    },
+    "v202601.MarketDeletionItem": {
+      "fields": [
+        {
+          "name": "id",
+          "type": "string"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        }
+      ]
+    },
+    "v202601.MarketExchangeRate": {
+      "fields": [
+        {
+          "name": "currency",
+          "type": "string"
+        },
+        {
+          "name": "to_currency",
+          "type": "string"
+        },
+        {
+          "name": "rate",
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "name": "last_updated_at",
+          "type": "string"
+        }
+      ]
+    },
+    "v202601.MarketLanguage": {
+      "fields": [
+        {
+          "name": "code",
+          "type": "string"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "is_enabled",
+          "type": "boolean"
+        },
+        {
+          "name": "url",
+          "type": "string"
+        },
+        {
+          "name": "is_default",
+          "type": "boolean"
+        }
+      ]
+    },
+    "v202601.MarketListItem": {
+      "fields": [
+        {
+          "name": "id",
+          "type": "string"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "name": "is_primary",
+          "type": "boolean"
+        },
+        {
+          "name": "is_default",
+          "type": "boolean"
+        },
+        {
+          "name": "market_status",
+          "type": "string"
+        },
+        {
+          "name": "countries",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "currency",
+          "type": "string"
+        },
+        {
+          "name": "symbol",
+          "type": "object",
+          "schema": "v202601.MarketCurrencySymbol"
+        },
+        {
+          "name": "local_currency_enabled",
+          "type": "boolean"
+        },
+        {
+          "name": "countries_detail",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "schema": "v202601.MarketCountryCurrencyDetail"
+          }
         }
       ]
     },
@@ -20711,6 +22037,89 @@
         }
       ]
     },
+    "v202601.MarketProduct": {
+      "fields": [
+        {
+          "name": "id",
+          "type": "string"
+        },
+        {
+          "name": "title",
+          "type": "string"
+        },
+        {
+          "name": "price_min",
+          "type": "string"
+        },
+        {
+          "name": "price_max",
+          "type": "string"
+        },
+        {
+          "name": "image",
+          "type": "object",
+          "schema": "v202601.MarketProductImage"
+        },
+        {
+          "name": "is_excluded",
+          "type": "boolean"
+        },
+        {
+          "name": "total_fixed_price",
+          "type": "integer",
+          "format": "int32"
+        },
+        {
+          "name": "total_variants",
+          "type": "integer",
+          "format": "int32"
+        }
+      ]
+    },
+    "v202601.MarketProductImage": {
+      "fields": [
+        {
+          "name": "src",
+          "type": "string"
+        },
+        {
+          "name": "alt",
+          "type": "string"
+        },
+        {
+          "name": "width",
+          "type": "integer",
+          "format": "int32"
+        },
+        {
+          "name": "height",
+          "type": "integer",
+          "format": "int32"
+        },
+        {
+          "name": "path",
+          "type": "string"
+        }
+      ]
+    },
+    "v202601.MarketProductPriceItem": {
+      "fields": [
+        {
+          "name": "id",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "operation",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "fixed_price",
+          "type": "string"
+        }
+      ]
+    },
     "v202601.MarketSetting": {
       "fields": [
         {
@@ -20768,6 +22177,26 @@
         {
           "name": "market_country",
           "type": "string"
+        }
+      ]
+    },
+    "v202601.MarketStorefrontSetting": {
+      "fields": [
+        {
+          "name": "redirect_enabled",
+          "type": "boolean"
+        },
+        {
+          "name": "price_round_enabled",
+          "type": "boolean"
+        },
+        {
+          "name": "geolocation_app_installed",
+          "type": "boolean"
+        },
+        {
+          "name": "language_selector_enabled",
+          "type": "boolean"
         }
       ]
     },
@@ -21249,6 +22678,24 @@
         }
       ]
     },
+    "v202601.PreviewMarketResponse": {
+      "fields": [
+        {
+          "name": "count",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "name": "markets",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "schema": "v202601.MarketDeletionItem"
+          }
+        }
+      ]
+    },
+    "v202601.PublishLanguageToMarketsResponse": {},
     "v202601.Rule": {
       "fields": [
         {
@@ -21331,6 +22778,18 @@
           "name": "delivery_method",
           "type": "integer",
           "format": "int32"
+        }
+      ]
+    },
+    "v202601.SupportedLanguage": {
+      "fields": [
+        {
+          "name": "code",
+          "type": "string"
+        },
+        {
+          "name": "name",
+          "type": "string"
         }
       ]
     },
@@ -21460,6 +22919,13 @@
         }
       ]
     },
+    "v202601.UpdateMarketDefaultLanguageResponse": {},
+    "v202601.UpdateMarketDomainResponse": {},
+    "v202601.UpdateMarketPriceResponse": {},
+    "v202601.UpdateMarketProductPricesResponse": {},
+    "v202601.UpdateMarketResponse": {},
+    "v202601.UpdateMarketStatusResponse": {},
+    "v202601.UpdateMarketTaxResponse": {},
     "v202601.UpdateOrderParam": {
       "fields": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shoplazza-cli",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "The official CLI for Shoplazza Open Platform",
   "bin": {
     "shoplazza": "scripts/run.js"


### PR DESCRIPTION
Releases **2.0.6**. Bundles the `auth login --domain app` / partner-token work with a CLI-metadata refresh.

## Auth — `--domain app` scopes + partner-token preservation
- **`auth login --domain app`** now expands to app-extension development scopes — `read_themes write_themes` (plus implied `read_shop` for theme previews), covering themes, checkout, and theme-extension uploads — instead of the app template's install scopes (`read_customer write_cart_transform`).
- **Partner token no longer dropped by routine logins.** A store-scoped or `--uat` login of the same account carries no partner token; it used to wipe the stored one, forcing an interactive re-login for every `app` command. It is now preserved for the same account and cleared only on an account switch or explicit logout.
- **Account match is now case-insensitive** (`strings.EqualFold`). The interactive (poll) and `--uat` (Me) login paths can echo the same email with different casing; an exact compare would silently wipe a valid partner token — reintroducing the very regression the preservation logic fixes. Covered by a new regression test.
- Simplified the `--domain app` expansion: `themes` and `checkout` share the `themes` scope base, so the sub-domain loop collapsed to a single `ExpandDomain("themes")` — dropping dead iteration and a latent surprise if `checkout` is ever remapped.

## Registry — CLI metadata refresh
- Adds the store **`languages`** command group (add / enable / disable / publish-to-market / delete) and refines the product-search `filter` param description. Metadata-only (`chore(registry)`).

## Verification
- `go build ./...` and `go test ./...` both green (exit 0) on the committed state.
- New test `TestPersistState_PreservesPartnerAcrossAccountCasing` reproduced RED before the `EqualFold` fix, GREEN after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
