### PR TITLE
fix(core): valid profile name for Windows-reserved subdomains

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -62,6 +62,13 @@ func DeriveProfileName(domain string, taken func(string) bool) string {
 	if strings.HasSuffix(domain, ".myshoplazza.com") {
 		base = strings.TrimSuffix(domain, ".myshoplazza.com")
 	}
+	// A subdomain that is a Windows-reserved device name (con/nul/com3…) or is
+	// otherwise not a valid profile name must not become one verbatim: the
+	// auto-created profile's meta file would be unusable. Suffix to make it valid
+	// while keeping it recognizable.
+	if ValidateProfileName(base) != nil {
+		base += "-store"
+	}
 	name := base
 	for i := 2; taken(name); i++ {
 		name = fmt.Sprintf("%s-%d", base, i)

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -165,6 +165,20 @@ func TestDeriveProfileName(t *testing.T) {
 	}
 }
 
+// A store subdomain that is a Windows-reserved device name (e.g. "con") must not
+// derive to that bare name — the auto-created profile's meta file (con.json) is
+// unusable on Windows. The derived name must always pass ValidateProfileName.
+func TestDeriveProfileName_ReservedNameStaysValid(t *testing.T) {
+	notTaken := func(string) bool { return false }
+	got := DeriveProfileName("con.myshoplazza.com", notTaken)
+	if got == "con" {
+		t.Fatalf("derived name must not be the bare reserved word %q", got)
+	}
+	if err := ValidateProfileName(got); err != nil {
+		t.Fatalf("derived name %q must be a valid profile name, got: %v", got, err)
+	}
+}
+
 func TestFindProfile_CaseInsensitive(t *testing.T) {
 	c := CliConfig{Profiles: []ProfileConfig{{Name: "prod-us", StoreDomain: "us.myshoplazza.com"}}}
 	if c.FindProfile("Prod-US") == nil || c.FindProfileByStore("US.myshoplazza.com") == nil {


### PR DESCRIPTION
## What
`core.DeriveProfileName` could produce a profile name equal to a Windows-reserved device name (`con`, `nul`, `com1`–`com9`, `lpt1`–`lpt9`, …) when a store subdomain matched one — e.g. `con.myshoplazza.com` → `con`, whose on-disk profile meta file `con.json` cannot be created on Windows.

Manual `profile add --name` runs `ValidateProfileName`, but the **auto-derive paths** (login-time `SyncAfterLogin`, v1→v2 `migrate`) do not — so an invalid name could silently reach disk.

## Fix
In `DeriveProfileName`, if the derived label fails `ValidateProfileName` (reserved word or otherwise invalid), suffix it (`-store`) to make it valid while staying recognizable. Normal names are unchanged (`cn.myshoplazza.com` → `cn`, custom domains keep the full host).

## Test
Adds `TestDeriveProfileName_ReservedNameStaysValid` (`con.myshoplazza.com` must not derive the bare `con` and must pass `ValidateProfileName`). Verified RED before the fix, GREEN after; existing `TestDeriveProfileName` and the full `internal/core` suite stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)