### PR TITLE
fix(auth): login persists UAT under the v2 key the profile gate reads (BUG-01)

### DIFF
--- a/cmd/auth/login_gate_integration_test.go
+++ b/cmd/auth/login_gate_integration_test.go
@@ -1,0 +1,64 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	internalauth "shoplazza-cli-v2/internal/auth"
+	"shoplazza-cli-v2/internal/core"
+)
+
+// TestLoginThenGate_StoreTokenReady is the "real login output → Gate input"
+// seam that unit fixtures (which seed v2 keys directly) skipped. It reproduces
+// BUG-01: `auth login` persisted the UAT under a v1 keychain key while the Gate
+// reads the v2 account-namespaced key, so the first store command after login
+// failed with "no UAT available". A real login must leave the Gate able to mint
+// a store token for the profile it created.
+func TestLoginThenGate_StoreTokenReady(t *testing.T) {
+	store := "gate-store.myshoplaza.com"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/saiga/cli/auth/me":
+			_ = json.NewEncoder(w).Encode(map[string]any{"account": "alice@example.com", "user_id": "u-1"})
+		case "/api/saiga/cli/auth/exchange/store-at":
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": "Success", "data": map[string]any{
+				"access_token": "at-gate", "store_id": "100001", "store_domain": store,
+				"granted_scopes": []string{"read_product"}, "at_expires_at": "2099-01-01T00:00:00Z",
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	f, out := tempAuthFactory(t, srv.URL)
+	if err := execAuth(t, f, out, "login", "--uat", "uat-abc", "--store-domain", store); err != nil {
+		t.Fatalf("login failed: %v", err)
+	}
+
+	// Reload the config login wrote and resolve the profile it created.
+	cfg, err := core.LoadConfig(f.ConfigPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	p := cfg.Current()
+	if p == nil {
+		t.Fatalf("login did not create/select a profile: %+v", cfg)
+	}
+
+	// The Gate path a store command runs: mint/get the profile's store token.
+	// This calls AccountUAT(profile.Account) under the hood — the exact read the
+	// login write must line up with.
+	mgr := internalauth.NewManager(cfg, f.ConfigPath, f.AuthClient)
+	tok, err := mgr.AccessTokenReadyForProfile(context.Background(), f.ConfigPath, *p)
+	if err != nil {
+		t.Fatalf("gate could not ready a store token after login (BUG-01 namespace split): %v", err)
+	}
+	if tok == "" {
+		t.Fatal("gate returned an empty store token")
+	}
+}

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -187,6 +187,8 @@ func (m *Manager) Logout() (Status, error) {
 	}
 	_ = keychain.Remove(keychain.ShoplazzaCliService, kcUAT)
 	_ = keychain.Remove(keychain.ShoplazzaCliService, kcPartner)
+	_ = keychain.Remove(keychain.ShoplazzaCliService, AccountUATKey(state.Account))
+	_ = keychain.Remove(keychain.ShoplazzaCliService, AccountPartnerKey(state.Account))
 	for dom := range state.Stores { // auth.json map is the authoritative removal list
 		_ = keychain.Remove(keychain.ShoplazzaCliService, storeKcKey(dom))
 	}

--- a/internal/auth/persist.go
+++ b/internal/auth/persist.go
@@ -15,10 +15,13 @@ const (
 	kcPartner = "partner"
 )
 
-// storeKcKey / appKcKey build the resource-scoped keychain account names.
-// Account-level tokens (uat, partner) use the bare kind as the account name;
-// resource-level tokens carry a "<kind>:<id>" suffix so one host can hold
-// many stores / apps without collision.
+// storeKcKey / appKcKey build the resource-scoped keychain account names for
+// store/app tokens: a "<kind>:<id>" suffix lets one host hold many stores /
+// apps without collision. Account-level tokens (uat, partner) are written under
+// BOTH the legacy bare keys (kcUAT/kcPartner — read by LoadState and the v1
+// store/app flows) AND the v2 AccountUATKey/AccountPartnerKey namespace (read by
+// the profile Gate) during the v1→v2 transition, so login persists exactly what
+// every reader looks up. Unifying on the v2 keys alone is follow-up T15 cleanup.
 func storeKcKey(domain string) string { return "store:" + domain }
 func appKcKey(clientID string) string { return "app:" + clientID }
 
@@ -35,7 +38,7 @@ func (m *Manager) persistState(state AuthState) error {
 		// Match case-insensitively: poll and Me may echo the same email in
 		// different casing, and a mismatch would wrongly wipe a valid token.
 		if prev, err := loadAuthMeta(m.AuthPath); err == nil && prev.Account != "" && strings.EqualFold(prev.Account, state.Account) {
-			if existing, gerr := keychain.Get(keychain.ShoplazzaCliService, kcPartner); gerr == nil && existing != "" {
+			if existing, gerr := keychain.Get(keychain.ShoplazzaCliService, AccountPartnerKey(state.Account)); gerr == nil && existing != "" {
 				partner, partnerExpiresAt = existing, prev.PartnerExpiresAt
 			}
 		}
@@ -59,18 +62,25 @@ func (m *Manager) persistState(state AuthState) error {
 		return err
 	}
 	if state.UAT != "" {
+		if err := keychain.Set(keychain.ShoplazzaCliService, AccountUATKey(state.Account), state.UAT); err != nil {
+			return err
+		}
 		if err := keychain.Set(keychain.ShoplazzaCliService, kcUAT, state.UAT); err != nil {
 			return err
 		}
 	}
 	if partner != "" {
+		if err := keychain.Set(keychain.ShoplazzaCliService, AccountPartnerKey(state.Account), partner); err != nil {
+			return err
+		}
 		if err := keychain.Set(keychain.ShoplazzaCliService, kcPartner, partner); err != nil {
 			return err
 		}
 	} else {
 		// Empty here means either a first login with no partner token, or an
-		// account switch — drop any lingering entry so LoadState can't resurrect
-		// a different account's partner token.
+		// account switch — drop any lingering entry so a subsequent LoadState
+		// can't resurrect a different account's partner token.
+		_ = keychain.Remove(keychain.ShoplazzaCliService, AccountPartnerKey(state.Account))
 		_ = keychain.Remove(keychain.ShoplazzaCliService, kcPartner)
 	}
 	for dom, s := range state.Stores {

--- a/internal/auth/saiga_test.go
+++ b/internal/auth/saiga_test.go
@@ -90,8 +90,10 @@ func TestParseSaigaAuthError(t *testing.T) {
 }
 
 // TestStoreAppKcKey guards the keychain key contract from the package-internal
-// side: the account-level kind constants must not drift (old on-disk keys would
-// be orphaned) and the resource-scoped builders must keep their prefixes.
+// side: resource-scoped store/app builders keep their "<kind>:<id>" prefix, the
+// legacy account-kind constants must not drift (v1 on-disk keys would be
+// orphaned), and the v2 account builders keep the namespaced format the profile
+// Gate reads — drift there silently re-opens the login/Gate split (BUG-01).
 func TestStoreAppKcKey(t *testing.T) {
 	if got := storeKcKey("my-store.com"); got != "store:my-store.com" {
 		t.Errorf("storeKcKey = %q", got)
@@ -101,5 +103,11 @@ func TestStoreAppKcKey(t *testing.T) {
 	}
 	if kcUAT != "uat" || kcPartner != "partner" {
 		t.Errorf("account-level kinds drifted: kcUAT=%q kcPartner=%q", kcUAT, kcPartner)
+	}
+	if got := AccountUATKey("Alice@Co.com"); got != "account:alice@co.com:uat" {
+		t.Errorf("AccountUATKey = %q", got)
+	}
+	if got := AccountPartnerKey("Alice@Co.com"); got != "account:alice@co.com:partner" {
+		t.Errorf("AccountPartnerKey = %q", got)
 	}
 }


### PR DESCRIPTION
## Root cause (BUG-01, P0 — release blocker)
Found via the multi-tenant test-execution record: after a fresh `auth login`, the **first store-level command failed with `no UAT available`**, breaking the `login → business command` chain in the real binary.

The login write path (`persistState`) stored the account UAT under the legacy bare keychain key `"uat"`, but the v2 profile **gate read path** (`AccountUAT`) reads `account:<email>:uat`. Namespace split → the gate never found the freshly-written UAT. It slipped past CI because the gate/refresh unit fixtures seed the v2 key directly (`seedAccountUAT`) and never exercised the real `login → gate` seam.

## Fix
`persistState` now **dual-writes** the account UAT/partner under both:
- the v2 `AccountUATKey`/`AccountPartnerKey` namespace (what the profile gate reads), and
- the legacy bare keys (still read by `LoadState` and the v1 store/app flows during the transition).

`Logout` clears both. `LoadState` and the v1 flows are unchanged, so nothing else destabilizes.

## Test
Adds `TestLoginThenGate_StoreTokenReady` in `cmd/auth` — a real `auth login --uat -s <store>` (mock saiga) followed by the gate's `AccessTokenReadyForProfile`. **RED before the fix** (`no UAT available`), **GREEN after**. `saiga_test.go` now also guards the v2 key-builder format so this split can't silently reopen.

Full suite green (the only failure in a full run is the pre-existing `internal/theme/watch` parallel-load flake, which passes in isolation — unrelated).

## Follow-ups (not in this PR)
- Complete the v1→v2 credential unification (drop the legacy `"uat"`/`"partner"`/`"store:<domain>"` keys, migrate `LoadState` + the v1 `UseStore`/`StoreIDFor`/app flows to v2) — finishing the T15 cleanup.
- BUG-02 (P2): config-lock timeout error prints bare text + usage instead of the `internal/output` JSON envelope with a hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)