### PR TITLE
refactor(auth): unify account credentials on the v2 keychain keys (finish T15)

### DIFF
--- a/cmd/app/common_test.go
+++ b/cmd/app/common_test.go
@@ -48,15 +48,15 @@ func TestDashboardClient_DoesNotMutateAuthClient(t *testing.T) {
 	t.Setenv("SHOPLAZZA_ACCESS_TOKEN", "")
 
 	// Seed UAT + partner token in the isolated keychain so PartnerToken() succeeds.
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat_1"); err != nil {
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("alice@co.com"), "uat_1"); err != nil {
 		t.Fatalf("keychain Set uat: %v", err)
 	}
-	if err := keychain.Set(keychain.ShoplazzaCliService, "partner", "ptok_1"); err != nil {
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountPartnerKey("alice@co.com"), "ptok_1"); err != nil {
 		t.Fatalf("keychain Set partner: %v", err)
 	}
 
 	f := &cmdutil.Factory{
-		Config:     core.CliConfig{},
+		Config:     core.CliConfig{Accounts: []core.AccountConfig{{Name: "alice@co.com"}}},
 		ConfigPath: filepath.Join(dir, "config.json"),
 		AuthClient: client.New("https://partners.example.com"),
 	}
@@ -72,23 +72,22 @@ func TestDashboardClient_DoesNotMutateAuthClient(t *testing.T) {
 	}
 }
 
-// seedLoginKeychain isolates HOME/keychain to a temp dir and seeds UAT +
-// partner token so requireLogin/dashboardClient-style helpers get past the
-// login gate. Also seeds a v2 account UAT (storeTokenForDomain's
-// ExchangeEphemeral path reads Config.Accounts, not the legacy "uat" key).
-// Returns the isolated dir (for ConfigPath).
+// seedLoginKeychain isolates HOME/keychain to a temp dir and seeds the v2
+// account UAT + partner token (keyed to "alice@co.com") so
+// requireLogin/dashboardClient-style helpers get past the login gate.
+// Callers must give their Factory's Config a matching
+// Accounts: []core.AccountConfig{{Name: "alice@co.com"}} (or an equivalent
+// auth.json) so LoadState resolves the same account. Returns the isolated
+// dir (for ConfigPath).
 func seedLoginKeychain(t *testing.T) string {
 	t.Helper()
 	dir := testenv.IsolateConfigDir(t)
 	t.Setenv("SHOPLAZZA_ACCESS_TOKEN", "")
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat_1"); err != nil {
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("alice@co.com"), "uat_1"); err != nil {
 		t.Fatalf("keychain Set uat: %v", err)
 	}
-	if err := keychain.Set(keychain.ShoplazzaCliService, "partner", "ptok_1"); err != nil {
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountPartnerKey("alice@co.com"), "ptok_1"); err != nil {
 		t.Fatalf("keychain Set partner: %v", err)
-	}
-	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("alice@co.com"), "uat_1"); err != nil {
-		t.Fatalf("keychain Set account uat: %v", err)
 	}
 	return dir
 }
@@ -181,7 +180,7 @@ func TestPartnerOpenapiClient_NetError_RoutesToErrNetwork(t *testing.T) {
 	dir := seedLoginKeychain(t)
 	dead := deadServerURL(t)
 	f := &cmdutil.Factory{
-		Config:     core.CliConfig{},
+		Config:     core.CliConfig{Accounts: []core.AccountConfig{{Name: "alice@co.com"}}},
 		ConfigPath: filepath.Join(dir, "config.json"),
 		AuthClient: client.New(dead),
 	}
@@ -205,6 +204,7 @@ func TestDashboardClient_WarnsOnUserIDFailure(t *testing.T) {
 	f := &cmdutil.Factory{
 		IOStreams: cmdutil.IOStreams{ErrOut: &errBuf},
 		Config: core.CliConfig{
+			Accounts:       []core.AccountConfig{{Name: "alice@co.com"}},
 			CurrentProfile: "demo",
 			Profiles:       []core.ProfileConfig{{Name: "demo", Account: "alice@co.com", StoreDomain: "demo.myshoplazza.com"}},
 		},
@@ -256,9 +256,9 @@ func TestResolveStoreID_EmptyWithNilError(t *testing.T) {
 func TestResolveStoreID_FromProfileConfig_NoV1Exchange(t *testing.T) {
 	dir := testenv.IsolateConfigDir(t)
 	t.Setenv("SHOPLAZZA_ACCESS_TOKEN", "")
-	// A logged-in account (legacy UAT) so the old code path COULD reach the
-	// v1 exchange if it were still consulted.
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat_seed"); err != nil {
+	// A logged-in account so the old code path COULD reach the v1 exchange if
+	// it were still consulted.
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("alice@co.com"), "uat_seed"); err != nil {
 		t.Fatalf("keychain Set uat: %v", err)
 	}
 
@@ -298,7 +298,7 @@ func TestResolveStoreID_FromProfileConfig_NoV1Exchange(t *testing.T) {
 func TestResolveStoreID_FromProfileMeta_NoV1Exchange(t *testing.T) {
 	dir := testenv.IsolateConfigDir(t)
 	t.Setenv("SHOPLAZZA_ACCESS_TOKEN", "")
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat_seed"); err != nil {
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("alice@co.com"), "uat_seed"); err != nil {
 		t.Fatalf("keychain Set uat: %v", err)
 	}
 

--- a/cmd/app/function_test.go
+++ b/cmd/app/function_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	internalauth "shoplazza-cli-v2/internal/auth"
 	"shoplazza-cli-v2/internal/client"
 	"shoplazza-cli-v2/internal/cmdutil"
 	"shoplazza-cli-v2/internal/core"
@@ -111,17 +112,17 @@ func TestFunctionListNoCurrentApp(t *testing.T) {
 	// passes — the test checks the no-current-app branch, not the auth gate.
 	dir := testenv.IsolateConfigDir(t)
 	t.Setenv("SHOPLAZZA_ACCESS_TOKEN", "")
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat_1"); err != nil {
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("alice@co.com"), "uat_1"); err != nil {
 		t.Fatalf("keychain Set uat: %v", err)
 	}
-	if err := keychain.Set(keychain.ShoplazzaCliService, "partner", "ptok_1"); err != nil {
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountPartnerKey("alice@co.com"), "ptok_1"); err != nil {
 		t.Fatalf("keychain Set partner: %v", err)
 	}
 
 	// empty project: no shoplazza.app.toml → p.ActiveConfig() read fails → validation
 	root := t.TempDir()
 	f := &cmdutil.Factory{
-		Config:     core.CliConfig{},
+		Config:     core.CliConfig{Accounts: []core.AccountConfig{{Name: "alice@co.com"}}},
 		ConfigPath: filepath.Join(dir, "config.json"),
 		AuthClient: client.New("https://partners.example.com"),
 	}

--- a/cmd/auth/store_test.go
+++ b/cmd/auth/store_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	cmdauth "shoplazza-cli-v2/cmd/auth"
+	internalauth "shoplazza-cli-v2/internal/auth"
 	"shoplazza-cli-v2/internal/cmdutil"
 	"shoplazza-cli-v2/internal/core"
 	"shoplazza-cli-v2/internal/keychain"
@@ -46,7 +47,8 @@ func TestStoreUse_Success(t *testing.T) {
 	defer srv.Close()
 
 	f, out := tempAuthFactory(t, srv.URL)
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat_seed"); err != nil {
+	f.Config.Accounts = []core.AccountConfig{{Name: "alice@example.com"}}
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("alice@example.com"), "uat_seed"); err != nil {
 		t.Fatal(err)
 	}
 	if err := execAuth(t, f, out, "store", "use", "--store-domain", "my-store.com"); err != nil {
@@ -80,7 +82,8 @@ func TestStoreUse_ScopesRequired422(t *testing.T) {
 	defer srv.Close()
 
 	f, _ := tempAuthFactory(t, srv.URL)
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat_seed"); err != nil {
+	f.Config.Accounts = []core.AccountConfig{{Name: "alice@example.com"}}
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("alice@example.com"), "uat_seed"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -120,7 +123,8 @@ func TestStoreUse_StoreNotFound404(t *testing.T) {
 	defer srv.Close()
 
 	f, _ := tempAuthFactory(t, srv.URL)
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat_seed"); err != nil {
+	f.Config.Accounts = []core.AccountConfig{{Name: "alice@example.com"}}
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("alice@example.com"), "uat_seed"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -167,7 +171,8 @@ func TestStoreUse_ScopeNotGranted_Errors(t *testing.T) {
 	defer srv.Close()
 
 	f, out := tempAuthFactory(t, srv.URL)
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat_seed"); err != nil {
+	f.Config.Accounts = []core.AccountConfig{{Name: "alice@example.com"}}
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("alice@example.com"), "uat_seed"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/theme_extension/adhoc_test.go
+++ b/cmd/theme_extension/adhoc_test.go
@@ -42,10 +42,9 @@ var teAllScopes = []string{"read_product", "write_product"}
 // already logged in (uat seeded in keychain) and one profile per storeName,
 // each bound to "<name>.myshoplazza.com". Local copy of cmd/auth's helper of
 // the same name (unexported, cross-package) — same pattern, no AuthClient set
-// (callers point it at their own exchange stub). Also seeds the legacy
-// keychain "uat" entry: te's requireLogin gate still checks v1 CurrentStatus
-// (state.UAT), which a real `auth login` always populates alongside the v2
-// account/profile state (Manager.Login → persistState, then SyncAfterLogin).
+// (callers point it at their own exchange stub). te's requireLogin gate reads
+// CurrentStatus (state.UAT) via the same v2 AccountUATKey, so seeding it here
+// covers both the login gate and the account/profile state.
 func seedLoggedInWithProfiles(t *testing.T, email string, storeNames ...string) *cmdutil.Factory {
 	t.Helper()
 	dir := testenv.IsolateConfigDir(t)
@@ -70,9 +69,6 @@ func seedLoggedInWithProfiles(t *testing.T, email string, storeNames ...string) 
 	}
 	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey(email), "uat-seed"); err != nil {
 		t.Fatalf("seed account uat: %v", err)
-	}
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat-seed"); err != nil {
-		t.Fatalf("seed legacy uat: %v", err)
 	}
 
 	return &cmdutil.Factory{

--- a/internal/app/acquire_test.go
+++ b/internal/app/acquire_test.go
@@ -19,7 +19,7 @@ func TestEnsureAppToken_FetchesSecretThenMints(t *testing.T) {
 	// Isolate config + keychain to temp (HOME/XDG drive os.UserConfigDir).
 	dir := testenv.IsolateConfigDir(t)
 	// Seed a UAT so AppTokenReady's logged-in gate passes.
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat_1"); err != nil {
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("alice@co.com"), "uat_1"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -54,7 +54,8 @@ func TestEnsureAppToken_FetchesSecretThenMints(t *testing.T) {
 	}))
 	defer saiga.Close()
 
-	mgr := internalauth.NewManager(core.CliConfig{}, filepath.Join(dir, "config.json"), client.New(saiga.URL))
+	cfg := core.CliConfig{Accounts: []core.AccountConfig{{Name: "alice@co.com"}}}
+	mgr := internalauth.NewManager(cfg, filepath.Join(dir, "config.json"), client.New(saiga.URL))
 	d := NewDashboard(client.New(dash.URL), "partner_tok")
 
 	tok, err := EnsureAppToken(context.Background(), d, mgr, "p1", "cid_1")

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -185,8 +185,6 @@ func (m *Manager) Logout() (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
-	_ = keychain.Remove(keychain.ShoplazzaCliService, kcUAT)
-	_ = keychain.Remove(keychain.ShoplazzaCliService, kcPartner)
 	_ = keychain.Remove(keychain.ShoplazzaCliService, AccountUATKey(state.Account))
 	_ = keychain.Remove(keychain.ShoplazzaCliService, AccountPartnerKey(state.Account))
 	for dom := range state.Stores { // auth.json map is the authoritative removal list
@@ -216,8 +214,17 @@ func (m *Manager) LoadState() (AuthState, error) {
 	if err != nil {
 		return AuthState{}, err
 	}
+	// The account keys the v2 credential lookups. auth.json is the canonical
+	// source (persistState writes it alongside the UAT); fall back to the v2
+	// config's account when auth.json is absent (e.g. before it is written).
+	account := meta.Account
+	if account == "" {
+		if a := m.Config.Account(); a != nil {
+			account = a.Name
+		}
+	}
 	state := AuthState{
-		Account:          meta.Account,
+		Account:          account,
 		UserID:           meta.UserID,
 		UATExpiresAt:     meta.UATExpiresAt,
 		PartnerExpiresAt: meta.PartnerExpiresAt,
@@ -229,12 +236,12 @@ func (m *Manager) LoadState() (AuthState, error) {
 	// Propagate genuine read/decrypt failures for UAT/partner: swallowing them
 	// makes a corrupted keychain look like "not logged in". The per-store/app
 	// loops below stay tolerant — a missing/corrupt token self-heals via re-mint.
-	uat, err := keychain.Get(keychain.ShoplazzaCliService, kcUAT)
+	uat, err := keychain.Get(keychain.ShoplazzaCliService, AccountUATKey(account))
 	if err != nil {
 		return AuthState{}, fmt.Errorf("reading UAT from keychain (it may be corrupted): %w", err)
 	}
 	state.UAT = uat
-	partner, err := keychain.Get(keychain.ShoplazzaCliService, kcPartner)
+	partner, err := keychain.Get(keychain.ShoplazzaCliService, AccountPartnerKey(account))
 	if err != nil {
 		return AuthState{}, fmt.Errorf("reading partner token from keychain (it may be corrupted): %w", err)
 	}
@@ -335,8 +342,9 @@ func (m *Manager) AppTokenReady(ctx context.Context, clientID, clientSecret, par
 	return block.AccessToken, nil
 }
 
-// PartnerToken returns the account-level partner token (keychain "partner",
-// minted at login). Empty string means "not available" — caller maps that to a
+// PartnerToken returns the account-level partner token (keychain
+// AccountPartnerKey, minted at login). Empty string means "not available" —
+// caller maps that to a
 // re-login auth error.
 func (m *Manager) PartnerToken() (string, error) {
 	state, err := m.LoadState()

--- a/internal/auth/manager_test.go
+++ b/internal/auth/manager_test.go
@@ -571,7 +571,7 @@ func TestLoginUAT_PreservesPartnerTokenSameAccount(t *testing.T) {
 	if st.Partner != "pt_stale" {
 		t.Errorf("partner token should be preserved across a same-account --uat re-login, got %q", st.Partner)
 	}
-	if got, _ := keychain.Get(keychain.ShoplazzaCliService, "partner"); got != "pt_stale" {
+	if got, _ := keychain.Get(keychain.ShoplazzaCliService, internalauth.AccountPartnerKey("a@x.com")); got != "pt_stale" {
 		t.Errorf("partner keychain entry should be preserved for the same account, got %q", got)
 	}
 }

--- a/internal/auth/persist.go
+++ b/internal/auth/persist.go
@@ -10,18 +10,16 @@ import (
 	"shoplazza-cli-v2/internal/keychain"
 )
 
-const (
-	kcUAT     = "uat"
-	kcPartner = "partner"
-)
-
 // storeKcKey / appKcKey build the resource-scoped keychain account names for
 // store/app tokens: a "<kind>:<id>" suffix lets one host hold many stores /
-// apps without collision. Account-level tokens (uat, partner) are written under
-// BOTH the legacy bare keys (kcUAT/kcPartner — read by LoadState and the v1
-// store/app flows) AND the v2 AccountUATKey/AccountPartnerKey namespace (read by
-// the profile Gate) during the v1→v2 transition, so login persists exactly what
-// every reader looks up. Unifying on the v2 keys alone is follow-up T15 cleanup.
+// apps without collision. These remain the v1 eager-exchange cache still read
+// by AccessTokenReady/UseStore/StoreIDFor/AppTokenReady; migrating store tokens
+// onto the v2 ProfileStoreKey (per-profile) model is a separate change.
+//
+// Account-level tokens (uat, partner) are stored ONLY under the v2
+// AccountUATKey/AccountPartnerKey namespace — a single source of truth read by
+// both LoadState and the profile Gate (previously they were also mirrored to
+// legacy bare "uat"/"partner" keys; that transition bridge is now removed).
 func storeKcKey(domain string) string { return "store:" + domain }
 func appKcKey(clientID string) string { return "app:" + clientID }
 
@@ -65,23 +63,17 @@ func (m *Manager) persistState(state AuthState) error {
 		if err := keychain.Set(keychain.ShoplazzaCliService, AccountUATKey(state.Account), state.UAT); err != nil {
 			return err
 		}
-		if err := keychain.Set(keychain.ShoplazzaCliService, kcUAT, state.UAT); err != nil {
-			return err
-		}
 	}
 	if partner != "" {
 		if err := keychain.Set(keychain.ShoplazzaCliService, AccountPartnerKey(state.Account), partner); err != nil {
 			return err
 		}
-		if err := keychain.Set(keychain.ShoplazzaCliService, kcPartner, partner); err != nil {
-			return err
-		}
 	} else {
-		// Empty here means either a first login with no partner token, or an
-		// account switch — drop any lingering entry so a subsequent LoadState
-		// can't resurrect a different account's partner token.
+		// Empty here means a first login with no partner token, or an account
+		// switch — drop any lingering entry for THIS account so a later read
+		// can't resurrect a stale partner token. (Cross-account cleanup on a
+		// switch is SyncAfterLogin/wipeAccount's job at the command layer.)
 		_ = keychain.Remove(keychain.ShoplazzaCliService, AccountPartnerKey(state.Account))
-		_ = keychain.Remove(keychain.ShoplazzaCliService, kcPartner)
 	}
 	for dom, s := range state.Stores {
 		if s.Token != "" {

--- a/internal/auth/persist_partner_internal_test.go
+++ b/internal/auth/persist_partner_internal_test.go
@@ -36,7 +36,7 @@ func TestPersistState_PreservesPartnerAcrossSameAccountLogin(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if got, _ := keychain.Get(keychain.ShoplazzaCliService, kcPartner); got != "ptok_a" {
+	if got, _ := keychain.Get(keychain.ShoplazzaCliService, AccountPartnerKey("a@x.com")); got != "ptok_a" {
 		t.Fatalf("partner token wiped by same-account store login: got %q, want ptok_a", got)
 	}
 
@@ -44,7 +44,7 @@ func TestPersistState_PreservesPartnerAcrossSameAccountLogin(t *testing.T) {
 	if err := m.persistState(AuthState{Account: "b@y.com", UAT: "uat_b"}); err != nil {
 		t.Fatal(err)
 	}
-	if got, _ := keychain.Get(keychain.ShoplazzaCliService, kcPartner); got != "" {
+	if got, _ := keychain.Get(keychain.ShoplazzaCliService, AccountPartnerKey("b@y.com")); got != "" {
 		t.Fatalf("partner token should be cleared on account switch, got %q", got)
 	}
 }
@@ -72,7 +72,7 @@ func TestPersistState_PreservesPartnerAcrossAccountCasing(t *testing.T) {
 	if err := m.persistState(AuthState{Account: "user@x.com", UAT: "uat_a"}); err != nil {
 		t.Fatal(err)
 	}
-	if got, _ := keychain.Get(keychain.ShoplazzaCliService, kcPartner); got != "ptok_a" {
+	if got, _ := keychain.Get(keychain.ShoplazzaCliService, AccountPartnerKey("user@x.com")); got != "ptok_a" {
 		t.Fatalf("partner token wiped by account casing difference: got %q, want ptok_a", got)
 	}
 }

--- a/internal/auth/persist_test.go
+++ b/internal/auth/persist_test.go
@@ -108,7 +108,7 @@ func TestAppSlot_RoundTripAndLogoutCleanup(t *testing.T) {
 	if err := os.WriteFile(authPath, []byte(authJSON), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := keychain.Set(keychain.ShoplazzaCliService, "uat", "uat_x"); err != nil {
+	if err := keychain.Set(keychain.ShoplazzaCliService, internalauth.AccountUATKey("a@x.com"), "uat_x"); err != nil {
 		t.Fatal(err)
 	}
 	if err := keychain.Set(keychain.ShoplazzaCliService, "app:cid_42", "app_tok_secret"); err != nil {

--- a/internal/auth/saiga_test.go
+++ b/internal/auth/saiga_test.go
@@ -90,19 +90,15 @@ func TestParseSaigaAuthError(t *testing.T) {
 }
 
 // TestStoreAppKcKey guards the keychain key contract from the package-internal
-// side: resource-scoped store/app builders keep their "<kind>:<id>" prefix, the
-// legacy account-kind constants must not drift (v1 on-disk keys would be
-// orphaned), and the v2 account builders keep the namespaced format the profile
-// Gate reads — drift there silently re-opens the login/Gate split (BUG-01).
+// side: resource-scoped store/app builders keep their "<kind>:<id>" prefix, and
+// the v2 account builders keep the namespaced format the profile Gate reads —
+// drift there silently re-opens the login/Gate split (BUG-01).
 func TestStoreAppKcKey(t *testing.T) {
 	if got := storeKcKey("my-store.com"); got != "store:my-store.com" {
 		t.Errorf("storeKcKey = %q", got)
 	}
 	if got := appKcKey("cid_123"); got != "app:cid_123" {
 		t.Errorf("appKcKey = %q", got)
-	}
-	if kcUAT != "uat" || kcPartner != "partner" {
-		t.Errorf("account-level kinds drifted: kcUAT=%q kcPartner=%q", kcUAT, kcPartner)
 	}
 	if got := AccountUATKey("Alice@Co.com"); got != "account:alice@co.com:uat" {
 		t.Errorf("AccountUATKey = %q", got)

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -38,8 +38,8 @@ type AppState struct {
 type AuthState struct {
 	Account          string
 	UserID           string // login user id (poll/me user_id) — sent as login-user-id header
-	UAT              string // keychain "uat" — never serialized
-	Partner          string // keychain "partner" — never serialized
+	UAT              string // keychain AccountUATKey(account) — never serialized
+	Partner          string // keychain AccountPartnerKey(account) — never serialized
 	UATExpiresAt     string
 	PartnerExpiresAt string
 	GrantedScopes    []string // account-level; mirror of store-AT passthrough


### PR DESCRIPTION
Completes the v1→v2 keychain credential unification — removes the transition dual-write introduced by the BUG-01 fix (#21), so account credentials have a single source of truth.

## Changes
- **Account UAT/partner → v2 only.** `persistState` writes only `AccountUATKey`/`AccountPartnerKey`; `LoadState` reads them, sourcing the account from `auth.json` `meta.Account` with a fallback to the v2 config's `Account()`; `Logout` removes the v2 keys. The `kcUAT`/`kcPartner` constants are removed.
- **Store/app tokens stay v1 (scoped out).** `storeKcKey(domain)`/`appKcKey(clientID)` remain the eager-exchange cache read by `AccessTokenReady`/`UseStore`/`StoreIDFor`/`AppTokenReady`. Migrating those onto the per-profile `ProfileStoreKey` model reworks those flows and is a separate change (documented in `persist.go`).
- **Migration untouched** — still reads legacy bare `"uat"`/`"partner"` via `GetLegacy` for existing v1 installs.
- **Test fixtures migrated** to seed the v2 keys, adding a discoverable account (`Config.Accounts`) where a test previously seeded a bare key with no account.

## Verify
`go build ./... && go vet ./... && go test ./... -count=1` — **green, 52 packages, zero failures** (this run also passed the sometimes-flaky `internal/theme/watch`). `kcUAT`/`kcPartner` fully removed; residue grep for bare-key seeds is empty (a removed constant is a compile-time residue check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)